### PR TITLE
Add clientId header to non-admin endpoints

### DIFF
--- a/weddinggallery/src/main/java/com/weddinggallery/controller/CommentController.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/controller/CommentController.java
@@ -25,7 +25,8 @@ public class CommentController {
             summary = "Add comment to photo",
             description = "Creates a comment for the specified photo and returns the created comment")
     @ApiResponse(responseCode = "200", description = "Comment added")
-    public ResponseEntity<CommentResponse> addComment(@PathVariable Long photoId,
+    public ResponseEntity<CommentResponse> addComment(@RequestHeader(value = "X-client-Id", required = false) String clientId,
+                              @PathVariable Long photoId,
                               @RequestBody CommentRequest requestBody,
                               HttpServletRequest request) {
         CommentResponse response = commentService.addComment(photoId, requestBody.getText(), request);
@@ -36,7 +37,8 @@ public class CommentController {
     @Operation(summary = "Delete comment",
             description = "Deletes the comment if the requesting device is authorized")
     @ApiResponse(responseCode = "204", description = "Comment deleted")
-    public ResponseEntity<Void> deleteComment(@PathVariable Long id, HttpServletRequest request) {
+    public ResponseEntity<Void> deleteComment(@RequestHeader(value = "X-client-Id", required = false) String clientId,
+                              @PathVariable Long id, HttpServletRequest request) {
         commentService.deleteComment(id, request);
         return ResponseEntity.noContent().build();
     }

--- a/weddinggallery/src/main/java/com/weddinggallery/controller/PhotoController.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/controller/PhotoController.java
@@ -28,6 +28,7 @@ public class PhotoController {
     @GetMapping
     @Operation(summary = "Get all photos")
     public ResponseEntity<org.springframework.data.domain.Page<PhotoResponse>> getPhotos(
+            @RequestHeader(value = "X-client-Id", required = false) String clientId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size,
             @RequestParam(defaultValue = "uploadTime") String sortBy,
@@ -42,6 +43,7 @@ public class PhotoController {
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "Save a photo")
     public ResponseEntity<PhotoResponse> savePhoto(
+            @RequestHeader(value = "X-client-Id", required = false) String clientId,
             @RequestPart("file") MultipartFile file,
             @RequestPart(value = "description", required = false) String description,
             HttpServletRequest request
@@ -53,6 +55,7 @@ public class PhotoController {
     @PostMapping(value = "/batch", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "Save multiple photos")
     public ResponseEntity<java.util.List<com.weddinggallery.model.Photo>> savePhotos(
+            @RequestHeader(value = "X-client-Id", required = false) String clientId,
             @RequestPart("files") java.util.List<MultipartFile> files,
             @RequestPart(value = "descriptions", required = false) java.util.List<String> descriptions,
             HttpServletRequest request
@@ -81,6 +84,7 @@ public class PhotoController {
     @PutMapping("/{id}/description")
     @Operation(summary = "Update photo description")
     public ResponseEntity<PhotoResponse> updateDescription(
+            @RequestHeader(value = "X-client-Id", required = false) String clientId,
             @PathVariable Long id,
             @RequestBody PhotoDescriptionUpdateRequest updateRequest,
             HttpServletRequest request
@@ -92,6 +96,7 @@ public class PhotoController {
     @PutMapping("/{id}/visibility")
     @Operation(summary = "Update photo visibility")
     public ResponseEntity<PhotoResponse> updateVisibility(
+            @RequestHeader(value = "X-client-Id", required = false) String clientId,
             @PathVariable Long id,
             @RequestBody PhotoVisibilityUpdateRequest updateRequest,
             HttpServletRequest request

--- a/weddinggallery/src/main/java/com/weddinggallery/controller/ReactionController.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/controller/ReactionController.java
@@ -23,7 +23,8 @@ public class ReactionController {
     @Operation(summary = "Add reaction to photo",
             description = "Adds a reaction to the specified photo and returns it")
     @ApiResponse(responseCode = "200", description = "Reaction added")
-    public ResponseEntity<ReactionResponse> addReaction(@PathVariable Long photoId,
+    public ResponseEntity<ReactionResponse> addReaction(@RequestHeader(value = "X-client-Id", required = false) String clientId,
+                                @PathVariable Long photoId,
                                 @RequestBody ReactionRequest requestBody,
                                 HttpServletRequest request) {
         ReactionResponse response = reactionService.addReaction(photoId, requestBody.getType(), request);
@@ -34,7 +35,8 @@ public class ReactionController {
     @Operation(summary = "Delete reaction",
             description = "Deletes the reaction if the requesting device is authorized")
     @ApiResponse(responseCode = "204", description = "Reaction deleted")
-    public ResponseEntity<Void> deleteReaction(@PathVariable Long id, HttpServletRequest request) {
+    public ResponseEntity<Void> deleteReaction(@RequestHeader(value = "X-client-Id", required = false) String clientId,
+                                @PathVariable Long id, HttpServletRequest request) {
         reactionService.deleteReaction(id, request);
         return ResponseEntity.noContent().build();
     }


### PR DESCRIPTION
## Summary
- include optional `X-client-Id` header on non-admin endpoints

## Testing
- `mvnw test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686ec4e90f78832e975c9df093402bc4