### PR TITLE
Allow video uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Upload several files at once. The request must use `multipart/form-data` with:
 - `files` – one or more image files
 - `descriptions` – optional descriptions matching file order
 
-Supported file extensions: `jpg`, `jpeg`, `png`, `gif`, `bmp`, `webp`, `heic`.
+Supported file extensions: `jpg`, `jpeg`, `png`, `gif`, `bmp`, `webp`, `heic`, `mp4`, `mov`, `avi`, `mkv`, `webm`.
 
 Include the JWT obtained from the login endpoint in the `Authorization: Bearer <token>` header.
 

--- a/weddinggallery/src/main/java/com/weddinggallery/service/PhotoService.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/service/PhotoService.java
@@ -47,8 +47,19 @@ public class PhotoService {
     private final JwtTokenProvider tokenProvider;
     private final StorageService storageService;
 
-    static final Set<String> ALLOWED_EXTENSIONS = Set.of(
+    static final Set<String> ALLOWED_IMAGE_EXTENSIONS = Set.of(
             "jpg", "jpeg", "png", "gif", "bmp", "webp", "heic"
+    );
+
+    static final Set<String> ALLOWED_VIDEO_EXTENSIONS = Set.of(
+            "mp4", "mov", "avi", "mkv", "webm"
+    );
+
+    static final Set<String> ALLOWED_EXTENSIONS = Set.copyOf(
+            java.util.stream.Stream.concat(
+                    ALLOWED_IMAGE_EXTENSIONS.stream(),
+                    ALLOWED_VIDEO_EXTENSIONS.stream()
+            ).collect(java.util.stream.Collectors.toSet())
     );
 
     public List<Photo> getAllPhotos(){

--- a/weddinggallery/src/test/java/com/weddinggallery/PhotoServiceTest.java
+++ b/weddinggallery/src/test/java/com/weddinggallery/PhotoServiceTest.java
@@ -59,7 +59,7 @@ class PhotoServiceTest {
     @Test
     void savesAllPhotosWhenExtensionsAllowed() throws Exception {
         MockMultipartFile file1 = new MockMultipartFile("files", "img1.jpg", "image/jpeg", new byte[0]);
-        MockMultipartFile file2 = new MockMultipartFile("files", "img2.png", "image/png", new byte[0]);
+        MockMultipartFile file2 = new MockMultipartFile("files", "video.mp4", "video/mp4", new byte[0]);
         HttpServletRequest req = mock(HttpServletRequest.class);
         when(req.getHeader("Authorization")).thenReturn("Bearer token");
         when(req.getHeader("X-client-Id")).thenReturn(device.getClientId().toString());

--- a/weddinggallery/src/test/java/com/weddinggallery/service/PhotoServiceTest.java
+++ b/weddinggallery/src/test/java/com/weddinggallery/service/PhotoServiceTest.java
@@ -56,13 +56,13 @@ class PhotoServiceTest {
 
     @Test
     void savesPhotoWhenExtensionAllowed() throws Exception {
-        MockMultipartFile file = new MockMultipartFile("file", "img.jpg", "image/jpeg", new byte[0]);
+        MockMultipartFile file = new MockMultipartFile("file", "video.mp4", "video/mp4", new byte[0]);
         HttpServletRequest req = mock(HttpServletRequest.class);
         when(req.getHeader("Authorization")).thenReturn("Bearer token");
         when(req.getHeader("X-client-Id")).thenReturn(device.getClientId().toString());
         when(tokenProvider.getClientIdFromToken("token")).thenReturn(device.getClientId().toString());
         when(deviceRepository.findByClientIdWithUser(device.getClientId())).thenReturn(Optional.of(device));
-        when(storageService.store(file)).thenReturn("stored.jpg");
+        when(storageService.store(file)).thenReturn("stored.mp4");
         when(photoRepository.save(any(Photo.class))).thenAnswer(invocation -> {
             Photo p = invocation.getArgument(0);
             p.setId(3L);
@@ -71,7 +71,7 @@ class PhotoServiceTest {
 
         var response = photoService.savePhoto(file, null, req);
 
-        assertThat(response.getFileName()).isEqualTo("stored.jpg");
+        assertThat(response.getFileName()).isEqualTo("stored.mp4");
         verify(storageService).store(file);
         verify(photoRepository).save(any(Photo.class));
     }


### PR DESCRIPTION
## Summary
- maintain lists of allowed image and video extensions
- validate uploads against combined allowed list
- test mp4 uploads
- document supported extensions

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686ee1d9bf94832ea9f0e3c0f92b4ee8