### PR TITLE
Add photo type filter

### DIFF
--- a/weddinggallery/src/main/java/com/weddinggallery/controller/PhotoController.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/controller/PhotoController.java
@@ -34,11 +34,12 @@ public class PhotoController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size,
             @RequestParam(defaultValue = "uploadTime") String sortBy,
-            @RequestParam(defaultValue = "desc") String direction
+            @RequestParam(defaultValue = "desc") String direction,
+            @RequestParam(required = false) String type
     ){
         org.springframework.data.domain.Pageable pageable = org.springframework.data.domain.PageRequest.of(page, size);
         org.springframework.data.domain.Sort sort = com.weddinggallery.util.SortUtil.from(sortBy, direction);
-        var result = photoService.getPhotos(pageable, sort);
+        var result = photoService.getPhotos(pageable, sort, type);
         return ResponseEntity.ok(result);
     }
 

--- a/weddinggallery/src/main/java/com/weddinggallery/repository/PhotoSpecifications.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/repository/PhotoSpecifications.java
@@ -17,5 +17,17 @@ public class PhotoSpecifications {
   public static Specification<Photo> isVisible(boolean visible) {
     return (root, query, cb) -> cb.equal(root.get("visible"), visible);
   }
+
+  public static Specification<Photo> withExtensions(java.util.Set<String> extensions) {
+    return (root, query, cb) -> {
+      if (extensions == null || extensions.isEmpty()) {
+        return null;
+      }
+      var predicates = extensions.stream()
+          .map(ext -> cb.like(cb.lower(root.get("fileName")), "%." + ext.toLowerCase()))
+          .toArray(jakarta.persistence.criteria.Predicate[]::new);
+      return cb.or(predicates);
+    };
+  }
 }
 

--- a/weddinggallery/src/main/java/com/weddinggallery/service/PhotoService.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/service/PhotoService.java
@@ -69,7 +69,16 @@ public class PhotoService {
         return photoRepository.findAll();
     }
 
-    public Page<PhotoResponse> getPhotos(Pageable pageable, Sort sort) {
+    public Page<PhotoResponse> getPhotos(Pageable pageable, Sort sort, String type) {
+        Set<String> extensions = null;
+        if (type != null) {
+            if ("image".equalsIgnoreCase(type)) {
+                extensions = ALLOWED_IMAGE_EXTENSIONS;
+            } else if ("video".equalsIgnoreCase(type)) {
+                extensions = ALLOWED_VIDEO_EXTENSIONS;
+            }
+        }
+
         PageRequest pageRequest = PageRequest.of(
                 pageable.getPageNumber(),
                 pageable.getPageSize(),
@@ -77,7 +86,8 @@ public class PhotoService {
         );
 
         return photoRepository
-                .findAll(PhotoSpecifications.isVisible(true), pageRequest)
+                .findAll(org.springframework.data.jpa.domain.Specification.where(PhotoSpecifications.isVisible(true))
+                        .and(PhotoSpecifications.withExtensions(extensions)), pageRequest)
                 .map(this::toResponse);
     }
 

--- a/weddinggallery/src/test/java/com/weddinggallery/controller/PhotoControllerMvcTest.java
+++ b/weddinggallery/src/test/java/com/weddinggallery/controller/PhotoControllerMvcTest.java
@@ -32,10 +32,10 @@ class PhotoControllerMvcTest {
 
     @Test
     void getPhotosReturnsOk() throws Exception {
-        Mockito.when(photoService.getPhotos(any(Pageable.class), any(Sort.class)))
+        Mockito.when(photoService.getPhotos(any(Pageable.class), any(Sort.class), any()))
                 .thenReturn(Page.empty());
 
-        mockMvc.perform(get("/api/photos"))
+        mockMvc.perform(get("/api/photos").param("type", "image"))
                 .andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
## Summary
- allow filtering photos by type
- implement extension-based specification
- update unit test for new param

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686ee57e5a34832e960aa8f94869a4a1