### PR TITLE
Add chat message entity

### DIFF
--- a/weddinggallery/src/main/java/com/weddinggallery/model/ChatMessage.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/model/ChatMessage.java
@@ -1,0 +1,28 @@
+package com.weddinggallery.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "chat_messages")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatMessage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "device_id")
+    private Device device;
+
+    @Column(columnDefinition = "TEXT")
+    private String text;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+}

--- a/weddinggallery/src/main/resources/db/migration/V14__create_chat_messages_table.sql
+++ b/weddinggallery/src/main/resources/db/migration/V14__create_chat_messages_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE chat_messages (
+    id BIGSERIAL PRIMARY KEY,
+    device_id BIGINT NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+    text TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT now()
+);


### PR DESCRIPTION
## Summary
- create `ChatMessage` entity mapped to new `chat_messages` table
- add Flyway migration to create the table

## Testing
- `mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686ef06c6aa0832ea9f382080d2bc432