### PR TITLE
Add ChatController for chat API

### DIFF
--- a/weddinggallery/src/main/java/com/weddinggallery/controller/ChatController.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/controller/ChatController.java
@@ -1,0 +1,47 @@
+package com.weddinggallery.controller;
+
+import com.weddinggallery.dto.chat.ChatMessageRequest;
+import com.weddinggallery.dto.chat.ChatMessageResponse;
+import com.weddinggallery.service.ChatService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/chat")
+@RequiredArgsConstructor
+@Tag(name = "Chat", description = "Chat message operations")
+public class ChatController {
+
+    private final ChatService chatService;
+
+    @PostMapping("/messages")
+    @Operation(summary = "Send chat message")
+    @ApiResponse(responseCode = "200", description = "Message sent")
+    public ResponseEntity<ChatMessageResponse> sendMessage(
+            @RequestHeader(value = "X-client-Id", required = false) String clientId,
+            @RequestBody ChatMessageRequest request,
+            HttpServletRequest httpRequest
+    ) {
+        ChatMessageResponse response = chatService.sendMessage(request.getText(), httpRequest);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/messages")
+    @Operation(summary = "Get chat messages")
+    public ResponseEntity<Page<ChatMessageResponse>> getMessages(
+            @RequestHeader(value = "X-client-Id", required = false) String clientId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        PageRequest pageRequest = PageRequest.of(page, size);
+        Page<ChatMessageResponse> messages = chatService.getMessages(pageRequest);
+        return ResponseEntity.ok(messages);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `ChatController` with `/api/chat` prefix
- expose endpoints for sending and listing chat messages

## Testing
- `mvnw test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686ef3246764832e86f47d548d0ada92