### PR TITLE
Add chat tests

### DIFF
--- a/weddinggallery/src/test/java/com/weddinggallery/controller/ChatControllerMvcTest.java
+++ b/weddinggallery/src/test/java/com/weddinggallery/controller/ChatControllerMvcTest.java
@@ -1,0 +1,55 @@
+package com.weddinggallery.controller;
+
+import com.weddinggallery.config.SecurityConfig;
+import com.weddinggallery.security.CustomUserDetailsService;
+import com.weddinggallery.security.JwtTokenProvider;
+import com.weddinggallery.service.ChatService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ChatController.class)
+@AutoConfigureMockMvc
+@Import(SecurityConfig.class)
+class ChatControllerMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ChatService chatService;
+
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @Test
+    void unauthenticatedRequestReturns401() throws Exception {
+        mockMvc.perform(get("/api/chat/messages"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser
+    void authenticatedRequestReturnsOk() throws Exception {
+        Mockito.when(chatService.getMessages(any(Pageable.class)))
+                .thenReturn(Page.empty());
+
+        mockMvc.perform(get("/api/chat/messages"))
+                .andExpect(status().isOk());
+    }
+}

--- a/weddinggallery/src/test/java/com/weddinggallery/service/ChatServiceTest.java
+++ b/weddinggallery/src/test/java/com/weddinggallery/service/ChatServiceTest.java
@@ -1,0 +1,98 @@
+package com.weddinggallery.service;
+
+import com.weddinggallery.model.ChatMessage;
+import com.weddinggallery.model.Device;
+import com.weddinggallery.model.User;
+import com.weddinggallery.repository.ChatMessageRepository;
+import com.weddinggallery.repository.DeviceRepository;
+import com.weddinggallery.security.JwtTokenProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ChatServiceTest {
+
+    @Mock
+    private ChatMessageRepository chatMessageRepository;
+    @Mock
+    private DeviceRepository deviceRepository;
+    @Mock
+    private JwtTokenProvider tokenProvider;
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    @InjectMocks
+    private ChatService chatService;
+
+    private Device device;
+
+    @BeforeEach
+    void setUp() {
+        User user = User.builder()
+                .id(1L)
+                .username("john")
+                .build();
+        device = Device.builder()
+                .id(2L)
+                .clientId(UUID.randomUUID())
+                .user(user)
+                .build();
+    }
+
+    @Test
+    void sendMessagePersistsAndBroadcasts() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getHeader("Authorization")).thenReturn("Bearer token");
+        when(req.getHeader("X-client-Id")).thenReturn(device.getClientId().toString());
+        when(tokenProvider.getClientIdFromToken("token")).thenReturn(device.getClientId().toString());
+        when(deviceRepository.findByClientIdWithUser(device.getClientId())).thenReturn(Optional.of(device));
+        ChatMessage saved = ChatMessage.builder()
+                .id(3L)
+                .device(device)
+                .text("hello")
+                .createdAt(LocalDateTime.now())
+                .build();
+        when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(saved);
+
+        var response = chatService.sendMessage("hello", req);
+
+        assertThat(response.getId()).isEqualTo(3L);
+        assertThat(response.getText()).isEqualTo("hello");
+        verify(chatMessageRepository).save(any(ChatMessage.class));
+        verify(messagingTemplate).convertAndSend(eq("/topic/chat"), any());
+    }
+
+    @Test
+    void missingAuthorizationHeaderThrows() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getHeader("Authorization")).thenReturn(null);
+
+        assertThrows(AccessDeniedException.class, () -> chatService.sendMessage("hi", req));
+    }
+
+    @Test
+    void clientIdMismatchThrows() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getHeader("Authorization")).thenReturn("Bearer token");
+        when(req.getHeader("X-client-Id")).thenReturn("other");
+        when(tokenProvider.getClientIdFromToken("token")).thenReturn(device.getClientId().toString());
+
+        assertThrows(AccessDeniedException.class, () -> chatService.sendMessage("hi", req));
+    }
+}


### PR DESCRIPTION
## Summary
- test device validation and persistence in `ChatService`
- test MVC behavior of `ChatController` for authentication and responses

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686f73286f3c832e943990a19a70eac7