### PR TITLE
Refactor device lookup logic into DeviceService

### DIFF
--- a/weddinggallery/src/main/java/com/weddinggallery/service/ChatService.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/service/ChatService.java
@@ -4,8 +4,7 @@ import com.weddinggallery.dto.chat.ChatMessageResponse;
 import com.weddinggallery.model.ChatMessage;
 import com.weddinggallery.model.Device;
 import com.weddinggallery.repository.ChatMessageRepository;
-import com.weddinggallery.repository.DeviceRepository;
-import com.weddinggallery.security.JwtTokenProvider;
+import com.weddinggallery.service.DeviceService;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -13,22 +12,19 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class ChatService {
     private final ChatMessageRepository chatMessageRepository;
-    private final DeviceRepository deviceRepository;
-    private final JwtTokenProvider tokenProvider;
+    private final DeviceService deviceService;
     private final SimpMessagingTemplate messagingTemplate;
 
     public ChatMessageResponse sendMessage(String text, HttpServletRequest request) {
-        Device device = getRequestingDevice(request);
+        Device device = deviceService.getRequestingDevice(request);
         ChatMessage message = ChatMessage.builder()
                 .device(device)
                 .text(text)
@@ -62,24 +58,4 @@ public class ChatService {
         );
     }
 
-    private Device getRequestingDevice(HttpServletRequest request) {
-        String authHeader = request.getHeader("Authorization");
-        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
-            throw new AccessDeniedException("Missing token");
-        }
-
-        String headerClientId = request.getHeader("X-client-Id");
-        if (headerClientId == null || headerClientId.isBlank()) {
-            throw new AccessDeniedException("Missing client id header");
-        }
-
-        String token = authHeader.substring(7);
-        String tokenClientId = tokenProvider.getClientIdFromToken(token);
-        if (!headerClientId.equals(tokenClientId)) {
-            throw new AccessDeniedException("Client id mismatch");
-        }
-
-        return deviceRepository.findByClientIdWithUser(UUID.fromString(tokenClientId))
-                .orElseThrow(() -> new AccessDeniedException("Device not found"));
-    }
 }

--- a/weddinggallery/src/main/java/com/weddinggallery/service/DeviceService.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/service/DeviceService.java
@@ -1,0 +1,39 @@
+package com.weddinggallery.service;
+
+import com.weddinggallery.model.Device;
+import com.weddinggallery.repository.DeviceRepository;
+import com.weddinggallery.security.JwtTokenProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class DeviceService {
+    private final DeviceRepository deviceRepository;
+    private final JwtTokenProvider tokenProvider;
+
+    public Device getRequestingDevice(HttpServletRequest request) {
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new AccessDeniedException("Missing token");
+        }
+
+        String headerClientId = request.getHeader("X-client-Id");
+        if (headerClientId == null || headerClientId.isBlank()) {
+            throw new AccessDeniedException("Missing client id header");
+        }
+
+        String token = authHeader.substring(7);
+        String tokenClientId = tokenProvider.getClientIdFromToken(token);
+        if (!headerClientId.equals(tokenClientId)) {
+            throw new AccessDeniedException("Client id mismatch");
+        }
+
+        return deviceRepository.findByClientIdWithUser(UUID.fromString(tokenClientId))
+                .orElseThrow(() -> new AccessDeniedException("Device not found"));
+    }
+}

--- a/weddinggallery/src/test/java/com/weddinggallery/PhotoServiceTest.java
+++ b/weddinggallery/src/test/java/com/weddinggallery/PhotoServiceTest.java
@@ -3,9 +3,8 @@ package com.weddinggallery;
 import com.weddinggallery.model.Device;
 import com.weddinggallery.model.Photo;
 import com.weddinggallery.model.User;
-import com.weddinggallery.repository.DeviceRepository;
 import com.weddinggallery.repository.PhotoRepository;
-import com.weddinggallery.security.JwtTokenProvider;
+import com.weddinggallery.service.DeviceService;
 import com.weddinggallery.service.PhotoService;
 import com.weddinggallery.service.StorageService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -32,9 +31,7 @@ class PhotoServiceTest {
     @Mock
     private PhotoRepository photoRepository;
     @Mock
-    private DeviceRepository deviceRepository;
-    @Mock
-    private JwtTokenProvider tokenProvider;
+    private DeviceService deviceService;
     @Mock
     private StorageService storageService;
 
@@ -61,10 +58,7 @@ class PhotoServiceTest {
         MockMultipartFile file1 = new MockMultipartFile("files", "img1.jpg", "image/jpeg", new byte[0]);
         MockMultipartFile file2 = new MockMultipartFile("files", "video.mp4", "video/mp4", new byte[0]);
         HttpServletRequest req = mock(HttpServletRequest.class);
-        when(req.getHeader("Authorization")).thenReturn("Bearer token");
-        when(req.getHeader("X-client-Id")).thenReturn(device.getClientId().toString());
-        when(tokenProvider.getClientIdFromToken("token")).thenReturn(device.getClientId().toString());
-        when(deviceRepository.findByClientIdWithUser(device.getClientId())).thenReturn(Optional.of(device));
+        when(deviceService.getRequestingDevice(req)).thenReturn(device);
         when(storageService.store(any(MultipartFile.class))).thenAnswer(inv -> ((MultipartFile) inv.getArgument(0)).getOriginalFilename());
         when(photoRepository.save(any(Photo.class))).thenAnswer(inv -> {
             Photo p = inv.getArgument(0);

--- a/weddinggallery/src/test/java/com/weddinggallery/service/ReactionServiceTest.java
+++ b/weddinggallery/src/test/java/com/weddinggallery/service/ReactionServiceTest.java
@@ -3,10 +3,9 @@ package com.weddinggallery.service;
 import com.weddinggallery.model.Device;
 import com.weddinggallery.model.Photo;
 import com.weddinggallery.model.Reaction;
-import com.weddinggallery.repository.DeviceRepository;
 import com.weddinggallery.repository.PhotoRepository;
 import com.weddinggallery.repository.ReactionRepository;
-import com.weddinggallery.security.JwtTokenProvider;
+import com.weddinggallery.service.DeviceService;
 import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,9 +32,7 @@ class ReactionServiceTest {
     @Mock
     private PhotoRepository photoRepository;
     @Mock
-    private DeviceRepository deviceRepository;
-    @Mock
-    private JwtTokenProvider tokenProvider;
+    private DeviceService deviceService;
 
     @InjectMocks
     private ReactionService reactionService;
@@ -64,10 +61,7 @@ class ReactionServiceTest {
     @Test
     void adminCanDeleteOthersReaction() {
         HttpServletRequest req = mock(HttpServletRequest.class);
-        when(req.getHeader("Authorization")).thenReturn("Bearer token");
-        when(req.getHeader("X-client-Id")).thenReturn(adminDevice.getClientId().toString());
-        when(tokenProvider.getClientIdFromToken("token")).thenReturn(adminDevice.getClientId().toString());
-        when(deviceRepository.findByClientId(adminDevice.getClientId())).thenReturn(Optional.of(adminDevice));
+        when(deviceService.getRequestingDevice(req)).thenReturn(adminDevice);
         when(reactionRepository.findById(3L)).thenReturn(Optional.of(reaction));
 
         SecurityContextHolder.getContext().setAuthentication(
@@ -83,10 +77,7 @@ class ReactionServiceTest {
     @Test
     void userCannotDeleteOthersReaction() {
         HttpServletRequest req = mock(HttpServletRequest.class);
-        when(req.getHeader("Authorization")).thenReturn("Bearer token");
-        when(req.getHeader("X-client-Id")).thenReturn(adminDevice.getClientId().toString());
-        when(tokenProvider.getClientIdFromToken("token")).thenReturn(adminDevice.getClientId().toString());
-        when(deviceRepository.findByClientId(adminDevice.getClientId())).thenReturn(Optional.of(adminDevice));
+        when(deviceService.getRequestingDevice(req)).thenReturn(adminDevice);
         when(reactionRepository.findById(3L)).thenReturn(Optional.of(reaction));
 
         SecurityContextHolder.getContext().setAuthentication(


### PR DESCRIPTION
## Summary
- centralize device lookup logic in new `DeviceService`
- use `DeviceService` from comment, photo, reaction and chat services
- update unit tests to mock `DeviceService`

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686f757b72ac832e9a940b535b5eb550