### PR TITLE
Add deviceName in API responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ On success the response contains the device identifier and a JWT token:
 ```json
 {
   "clientId": "<uuid>",
-  "token": "<jwt>"
+  "token": "<jwt>",
+  "deviceName": "<name>"
 }
 ```
 Include this token in the `Authorization: Bearer <token>` header when calling secured endpoints.
@@ -195,7 +196,8 @@ Response:
   "text": "Beautiful photo!",
   "createdAt": "2025-01-01T12:00:00",
   "photoId": 1,
-  "deviceId": 1
+  "deviceId": 1,
+  "deviceName": "Phone"
 }
 ```
 
@@ -224,7 +226,8 @@ Response:
   "id": 1,
   "type": "heart",
   "photoId": 1,
-  "deviceId": 1
+  "deviceId": 1,
+  "deviceName": "Phone"
 }
 ```
 
@@ -258,7 +261,8 @@ Response:
   "username": "alice",
   "text": "Hello there",
   "createdAt": "2025-01-01T12:00:00",
-  "deviceId": 1
+  "deviceId": 1,
+  "deviceName": "Phone"
 }
 ```
 
@@ -276,7 +280,8 @@ Response:
       "username": "alice",
       "text": "Hello there",
       "createdAt": "2025-01-01T12:00:00",
-      "deviceId": 1
+      "deviceId": 1,
+      "deviceName": "Phone"
     }
   ]
 }

--- a/weddinggallery/src/main/java/com/weddinggallery/auth/AuthService.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/auth/AuthService.java
@@ -86,7 +86,7 @@ public class AuthService {
                 device.getClientId().toString(),
                 shared.getRoles()
         );
-        return new AuthResponse(device.getClientId().toString(), token);
+        return new AuthResponse(device.getClientId().toString(), token, device.getName());
     }
 
 

--- a/weddinggallery/src/main/java/com/weddinggallery/dto/auth/AuthResponse.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/dto/auth/AuthResponse.java
@@ -8,5 +8,6 @@ import lombok.Data;
 public class AuthResponse {
     private String clientId;
     private String token;
+    private String deviceName;
 }
 

--- a/weddinggallery/src/main/java/com/weddinggallery/dto/chat/ChatMessageResponse.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/dto/chat/ChatMessageResponse.java
@@ -15,4 +15,5 @@ public class ChatMessageResponse {
     private String text;
     private LocalDateTime createdAt;
     private Long deviceId;
+    private String deviceName;
 }

--- a/weddinggallery/src/main/java/com/weddinggallery/dto/comment/CommentResponse.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/dto/comment/CommentResponse.java
@@ -15,5 +15,6 @@ public class CommentResponse {
     private LocalDateTime createdAt;
     private Long photoId;
     private Long deviceId;
+    private String deviceName;
 }
 

--- a/weddinggallery/src/main/java/com/weddinggallery/dto/photo/PhotoResponse.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/dto/photo/PhotoResponse.java
@@ -18,6 +18,7 @@ public class PhotoResponse {
     private int reactionCount;
     private String uploaderUsername;
     private Long deviceId;
+    private String deviceName;
     private boolean visible;
 }
 

--- a/weddinggallery/src/main/java/com/weddinggallery/dto/reaction/ReactionResponse.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/dto/reaction/ReactionResponse.java
@@ -12,5 +12,6 @@ public class ReactionResponse {
     private String type;
     private Long photoId;
     private Long deviceId;
+    private String deviceName;
 }
 

--- a/weddinggallery/src/main/java/com/weddinggallery/service/ChatService.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/service/ChatService.java
@@ -58,7 +58,8 @@ public class ChatService {
                         : null,
                 message.getText(),
                 message.getCreatedAt(),
-                message.getDevice() != null ? message.getDevice().getId() : null
+                message.getDevice() != null ? message.getDevice().getId() : null,
+                message.getDevice() != null ? message.getDevice().getName() : null
         );
     }
 

--- a/weddinggallery/src/main/java/com/weddinggallery/service/CommentService.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/service/CommentService.java
@@ -69,7 +69,8 @@ public class CommentService {
                 comment.getText(),
                 comment.getCreatedAt(),
                 comment.getPhoto() != null ? comment.getPhoto().getId() : null,
-                comment.getAuthor() != null ? comment.getAuthor().getId() : null
+                comment.getAuthor() != null ? comment.getAuthor().getId() : null,
+                comment.getAuthor() != null ? comment.getAuthor().getName() : null
         );
     }
 

--- a/weddinggallery/src/main/java/com/weddinggallery/service/PhotoService.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/service/PhotoService.java
@@ -259,6 +259,7 @@ public class PhotoService {
                 photo.getReactionCount(),
                 photo.getUploader() != null ? photo.getUploader().getUsername() : null,
                 photo.getDevice() != null ? photo.getDevice().getId() : null,
+                photo.getDevice() != null ? photo.getDevice().getName() : null,
                 photo.isVisible()
         );
     }

--- a/weddinggallery/src/main/java/com/weddinggallery/service/ReactionService.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/service/ReactionService.java
@@ -65,7 +65,8 @@ public class ReactionService {
                 reaction.getId(),
                 reaction.getType(),
                 reaction.getPhoto() != null ? reaction.getPhoto().getId() : null,
-                reaction.getDevice() != null ? reaction.getDevice().getId() : null
+                reaction.getDevice() != null ? reaction.getDevice().getId() : null,
+                reaction.getDevice() != null ? reaction.getDevice().getName() : null
         );
     }
 


### PR DESCRIPTION
## Summary
- include `deviceName` with device-related DTOs
- populate device name in response mappers
- return device name from the auth service
- document new `deviceName` field in README

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686f764a384c832e9ed14ce3be1d7872