### PR TITLE
Implement chat message reactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,29 @@ Response:
 }
 ```
 
+### POST `/api/chat/messages/{messageId}/reactions`
+Add an emoji reaction to a chat message.
+
+Request:
+```json
+{
+  "emoji": "\uD83D\uDE0A"
+}
+```
+Response:
+```json
+{
+  "id": 1,
+  "emoji": "\uD83D\uDE0A",
+  "messageId": 1,
+  "deviceId": 1,
+  "deviceName": "Phone"
+}
+```
+
+### DELETE `/api/chat/reactions/{id}`
+Deletes the reaction. Returns **204 No Content** on success.
+
 ## Error responses
 
 Errors are returned in JSON format by `GlobalExceptionHandler`:

--- a/weddinggallery/src/main/java/com/weddinggallery/controller/ChatReactionController.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/controller/ChatReactionController.java
@@ -1,0 +1,44 @@
+package com.weddinggallery.controller;
+
+import com.weddinggallery.dto.chat.ChatReactionRequest;
+import com.weddinggallery.dto.chat.ChatReactionResponse;
+import com.weddinggallery.service.ChatReactionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/chat")
+@RequiredArgsConstructor
+@Tag(name = "Chat Reactions", description = "Manage chat message reactions")
+public class ChatReactionController {
+
+    private final ChatReactionService chatReactionService;
+
+    @PostMapping("/messages/{messageId}/reactions")
+    @Operation(summary = "Add reaction to chat message")
+    @ApiResponse(responseCode = "200", description = "Reaction added")
+    public ResponseEntity<ChatReactionResponse> addReaction(
+            @RequestHeader(value = "X-client-Id", required = false) String clientId,
+            @PathVariable Long messageId,
+            @RequestBody ChatReactionRequest requestBody,
+            HttpServletRequest request) {
+        ChatReactionResponse response = chatReactionService.addReaction(messageId, requestBody.getEmoji(), request);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/reactions/{id}")
+    @Operation(summary = "Delete chat reaction")
+    @ApiResponse(responseCode = "204", description = "Reaction deleted")
+    public ResponseEntity<Void> deleteReaction(
+            @RequestHeader(value = "X-client-Id", required = false) String clientId,
+            @PathVariable Long id,
+            HttpServletRequest request) {
+        chatReactionService.deleteReaction(id, request);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/weddinggallery/src/main/java/com/weddinggallery/dto/chat/ChatReactionRequest.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/dto/chat/ChatReactionRequest.java
@@ -1,0 +1,12 @@
+package com.weddinggallery.dto.chat;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatReactionRequest {
+    private String emoji;
+}

--- a/weddinggallery/src/main/java/com/weddinggallery/dto/chat/ChatReactionResponse.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/dto/chat/ChatReactionResponse.java
@@ -1,0 +1,16 @@
+package com.weddinggallery.dto.chat;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatReactionResponse {
+    private Long id;
+    private String emoji;
+    private Long messageId;
+    private Long deviceId;
+    private String deviceName;
+}

--- a/weddinggallery/src/main/java/com/weddinggallery/model/ChatMessageReaction.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/model/ChatMessageReaction.java
@@ -1,0 +1,32 @@
+package com.weddinggallery.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "chat_message_reactions")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatMessageReaction {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "message_id", nullable = false)
+    private ChatMessage message;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "device_id", nullable = false)
+    private Device device;
+
+    @Column(nullable = false, length = 50)
+    private String emoji;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/weddinggallery/src/main/java/com/weddinggallery/repository/ChatMessageReactionRepository.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/repository/ChatMessageReactionRepository.java
@@ -1,0 +1,7 @@
+package com.weddinggallery.repository;
+
+import com.weddinggallery.model.ChatMessageReaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatMessageReactionRepository extends JpaRepository<ChatMessageReaction, Long> {
+}

--- a/weddinggallery/src/main/java/com/weddinggallery/service/ChatReactionService.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/service/ChatReactionService.java
@@ -1,0 +1,67 @@
+package com.weddinggallery.service;
+
+import com.weddinggallery.dto.chat.ChatReactionResponse;
+import com.weddinggallery.model.ChatMessage;
+import com.weddinggallery.model.ChatMessageReaction;
+import com.weddinggallery.model.Device;
+import com.weddinggallery.repository.ChatMessageReactionRepository;
+import com.weddinggallery.repository.ChatMessageRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class ChatReactionService {
+    private final ChatMessageReactionRepository reactionRepository;
+    private final ChatMessageRepository messageRepository;
+    private final DeviceService deviceService;
+
+    @Transactional
+    public ChatReactionResponse addReaction(Long messageId, String emoji, HttpServletRequest request) {
+        Device device = deviceService.getRequestingDevice(request);
+        ChatMessage message = messageRepository.findById(messageId)
+                .orElseThrow(() -> new AccessDeniedException("Message not found"));
+        ChatMessageReaction reaction = ChatMessageReaction.builder()
+                .message(message)
+                .device(device)
+                .emoji(emoji)
+                .createdAt(LocalDateTime.now())
+                .build();
+        ChatMessageReaction saved = reactionRepository.save(reaction);
+        return toResponse(saved);
+    }
+
+    @Transactional
+    public void deleteReaction(Long id, HttpServletRequest request) {
+        Device device = deviceService.getRequestingDevice(request);
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        boolean isAdmin = auth.getAuthorities().stream()
+                .anyMatch(a -> "ROLE_ADMIN".equals(a.getAuthority()));
+
+        ChatMessageReaction reaction = reactionRepository.findById(id)
+                .orElseThrow(() -> new AccessDeniedException("Reaction not found"));
+
+        if (!isAdmin && !reaction.getDevice().getId().equals(device.getId())) {
+            throw new AccessDeniedException("Not authorized to delete this reaction");
+        }
+
+        reactionRepository.delete(reaction);
+    }
+
+    private ChatReactionResponse toResponse(ChatMessageReaction reaction) {
+        return new ChatReactionResponse(
+                reaction.getId(),
+                reaction.getEmoji(),
+                reaction.getMessage() != null ? reaction.getMessage().getId() : null,
+                reaction.getDevice() != null ? reaction.getDevice().getId() : null,
+                reaction.getDevice() != null ? reaction.getDevice().getName() : null
+        );
+    }
+}

--- a/weddinggallery/src/main/resources/db/migration/V15__create_chat_message_reactions_table.sql
+++ b/weddinggallery/src/main/resources/db/migration/V15__create_chat_message_reactions_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE chat_message_reactions (
+    id BIGSERIAL PRIMARY KEY,
+    message_id BIGINT NOT NULL REFERENCES chat_messages(id) ON DELETE CASCADE,
+    device_id BIGINT NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+    emoji VARCHAR(50) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT now()
+);

--- a/weddinggallery/src/test/java/com/weddinggallery/service/ChatReactionServiceTest.java
+++ b/weddinggallery/src/test/java/com/weddinggallery/service/ChatReactionServiceTest.java
@@ -1,0 +1,90 @@
+package com.weddinggallery.service;
+
+import com.weddinggallery.model.ChatMessage;
+import com.weddinggallery.model.ChatMessageReaction;
+import com.weddinggallery.model.Device;
+import com.weddinggallery.repository.ChatMessageReactionRepository;
+import com.weddinggallery.repository.ChatMessageRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ChatReactionServiceTest {
+
+    @Mock
+    private ChatMessageReactionRepository reactionRepository;
+    @Mock
+    private ChatMessageRepository messageRepository;
+    @Mock
+    private DeviceService deviceService;
+
+    @InjectMocks
+    private ChatReactionService chatReactionService;
+
+    private Device adminDevice;
+    private ChatMessageReaction reaction;
+
+    @BeforeEach
+    void setUp() {
+        adminDevice = Device.builder()
+                .id(1L)
+                .clientId(UUID.randomUUID())
+                .build();
+        Device ownerDevice = Device.builder()
+                .id(2L)
+                .clientId(UUID.randomUUID())
+                .build();
+        reaction = ChatMessageReaction.builder()
+                .id(3L)
+                .message(ChatMessage.builder().id(5L).build())
+                .device(ownerDevice)
+                .build();
+    }
+
+    @Test
+    void adminCanDeleteOthersReaction() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(deviceService.getRequestingDevice(req)).thenReturn(adminDevice);
+        when(reactionRepository.findById(3L)).thenReturn(Optional.of(reaction));
+
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken("admin", "pass",
+                        List.of(new SimpleGrantedAuthority("ROLE_ADMIN"))));
+
+        chatReactionService.deleteReaction(3L, req);
+
+        verify(reactionRepository).delete(reaction);
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void userCannotDeleteOthersReaction() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(deviceService.getRequestingDevice(req)).thenReturn(adminDevice);
+        when(reactionRepository.findById(3L)).thenReturn(Optional.of(reaction));
+
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken("user", "pass",
+                        List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+
+        assertThrows(org.springframework.security.access.AccessDeniedException.class,
+                () -> chatReactionService.deleteReaction(3L, req));
+        verify(reactionRepository, never()).delete(any());
+        SecurityContextHolder.clearContext();
+    }
+}


### PR DESCRIPTION
## Summary
- allow emoji reactions on chat messages
- expose chat reaction endpoints and docs
- migrate DB for chat_message_reactions
- add ChatReactionService with controller and repository
- test deletion logic for chat reactions

## Testing
- `mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686f86d177e8832ebbfa87cd632bb641