### PR TITLE
Add endpoint to get chat reactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,22 @@ Response:
 }
 ```
 
+### GET `/api/chat/messages/{messageId}/reactions`
+Return the reactions for the message ordered by creation time.
+
+Response:
+```json
+[
+  {
+    "id": 1,
+    "emoji": "\uD83D\uDE0A",
+    "messageId": 1,
+    "deviceId": 1,
+    "deviceName": "Phone"
+  }
+]
+```
+
 ### DELETE `/api/chat/reactions/{id}`
 Deletes the reaction. Returns **204 No Content** on success.
 

--- a/weddinggallery/src/main/java/com/weddinggallery/controller/ChatReactionController.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/controller/ChatReactionController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -29,6 +30,15 @@ public class ChatReactionController {
             HttpServletRequest request) {
         ChatReactionResponse response = chatReactionService.addReaction(messageId, requestBody.getEmoji(), request);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/messages/{messageId}/reactions")
+    @Operation(summary = "Get reactions for chat message")
+    public ResponseEntity<List<ChatReactionResponse>> getReactions(
+            @RequestHeader(value = "X-client-Id", required = false) String clientId,
+            @PathVariable Long messageId) {
+        var responses = chatReactionService.getReactions(messageId);
+        return ResponseEntity.ok(responses);
     }
 
     @DeleteMapping("/reactions/{id}")

--- a/weddinggallery/src/main/java/com/weddinggallery/repository/ChatMessageReactionRepository.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/repository/ChatMessageReactionRepository.java
@@ -3,5 +3,8 @@ package com.weddinggallery.repository;
 import com.weddinggallery.model.ChatMessageReaction;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ChatMessageReactionRepository extends JpaRepository<ChatMessageReaction, Long> {
+    List<ChatMessageReaction> findByMessageIdOrderByCreatedAt(Long messageId);
 }

--- a/weddinggallery/src/main/java/com/weddinggallery/service/ChatReactionService.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/service/ChatReactionService.java
@@ -15,6 +15,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -53,6 +54,14 @@ public class ChatReactionService {
         }
 
         reactionRepository.delete(reaction);
+    }
+
+    @Transactional
+    public List<ChatReactionResponse> getReactions(Long messageId) {
+        return reactionRepository.findByMessageIdOrderByCreatedAt(messageId)
+                .stream()
+                .map(this::toResponse)
+                .toList();
     }
 
     private ChatReactionResponse toResponse(ChatMessageReaction reaction) {

--- a/weddinggallery/src/test/java/com/weddinggallery/service/ChatReactionServiceTest.java
+++ b/weddinggallery/src/test/java/com/weddinggallery/service/ChatReactionServiceTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
@@ -86,5 +87,29 @@ class ChatReactionServiceTest {
                 () -> chatReactionService.deleteReaction(3L, req));
         verify(reactionRepository, never()).delete(any());
         SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void getReactionsReturnsMappedResponses() {
+        ChatMessageReaction r1 = ChatMessageReaction.builder()
+                .id(10L)
+                .emoji(":)")
+                .message(ChatMessage.builder().id(5L).build())
+                .device(adminDevice)
+                .build();
+        ChatMessageReaction r2 = ChatMessageReaction.builder()
+                .id(11L)
+                .emoji("(")
+                .message(ChatMessage.builder().id(5L).build())
+                .device(adminDevice)
+                .build();
+        when(reactionRepository.findByMessageIdOrderByCreatedAt(5L))
+                .thenReturn(List.of(r1, r2));
+
+        var responses = chatReactionService.getReactions(5L);
+
+        assertThat(responses).hasSize(2);
+        assertThat(responses.get(0).getId()).isEqualTo(10L);
+        verify(reactionRepository).findByMessageIdOrderByCreatedAt(5L);
     }
 }


### PR DESCRIPTION
## Summary
- allow ordering chat message reactions by `createdAt`
- expose retrieval of chat reactions
- map ChatReactionService results to DTOs
- document the new endpoint
- test ChatReactionService.getReactions

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686fa5810df8832e966d40727cbe6342