### PR TITLE
Add comment retrieval endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,26 @@ Response:
 }
 ```
 
+### GET `/api/photos/{photoId}/comments`
+Return a page of comments for the photo ordered by creation time. Optional `page`
+and `size` parameters control pagination.
+
+Response:
+```json
+{
+  "content": [
+    {
+      "id": 1,
+      "text": "Beautiful photo!",
+      "createdAt": "2025-01-01T12:00:00",
+      "photoId": 1,
+      "deviceId": 1,
+      "deviceName": "Phone"
+    }
+  ]
+}
+```
+
 ### DELETE `/api/comments/{id}`
 Deletes the comment. Returns **204 No Content** on success.
 

--- a/weddinggallery/src/main/java/com/weddinggallery/controller/CommentController.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/controller/CommentController.java
@@ -33,6 +33,18 @@ public class CommentController {
         return ResponseEntity.ok(response);
     }
 
+    @GetMapping("/photos/{photoId}/comments")
+    @Operation(summary = "Get comments for photo")
+    public ResponseEntity<org.springframework.data.domain.Page<CommentResponse>> getComments(
+            @RequestHeader(value = "X-client-Id", required = false) String clientId,
+            @PathVariable Long photoId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        org.springframework.data.domain.PageRequest pageRequest = org.springframework.data.domain.PageRequest.of(page, size);
+        var comments = commentService.getComments(photoId, pageRequest);
+        return ResponseEntity.ok(comments);
+    }
+
     @DeleteMapping("/comments/{id}")
     @Operation(summary = "Delete comment",
             description = "Deletes the comment if the requesting device is authorized")

--- a/weddinggallery/src/main/java/com/weddinggallery/repository/CommentRepository.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/repository/CommentRepository.java
@@ -3,6 +3,9 @@ package com.weddinggallery.repository;
 import com.weddinggallery.model.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findByPhotoIdOrderByCreatedAt(Long photoId);
 }
 

--- a/weddinggallery/src/test/java/com/weddinggallery/service/CommentServiceTest.java
+++ b/weddinggallery/src/test/java/com/weddinggallery/service/CommentServiceTest.java
@@ -1,0 +1,88 @@
+package com.weddinggallery.service;
+
+import com.weddinggallery.model.Comment;
+import com.weddinggallery.model.Device;
+import com.weddinggallery.model.Photo;
+import com.weddinggallery.dto.comment.CommentResponse;
+import com.weddinggallery.repository.CommentRepository;
+import com.weddinggallery.repository.PhotoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CommentServiceTest {
+
+    @Mock
+    private CommentRepository commentRepository;
+    @Mock
+    private PhotoRepository photoRepository;
+    @Mock
+    private DeviceService deviceService;
+
+    @InjectMocks
+    private CommentService commentService;
+
+    private Comment c1;
+    private Comment c2;
+
+    @BeforeEach
+    void setUp() {
+        Device device = Device.builder()
+                .id(1L)
+                .clientId(UUID.randomUUID())
+                .name("Phone")
+                .build();
+        Photo photo = Photo.builder().id(5L).build();
+        c1 = Comment.builder()
+                .id(10L)
+                .text("first")
+                .createdAt(LocalDateTime.now())
+                .photo(photo)
+                .author(device)
+                .build();
+        c2 = Comment.builder()
+                .id(11L)
+                .text("second")
+                .createdAt(LocalDateTime.now())
+                .photo(photo)
+                .author(device)
+                .build();
+    }
+
+    @Test
+    void getCommentsPagesResults() {
+        when(commentRepository.findByPhotoIdOrderByCreatedAt(5L))
+                .thenReturn(List.of(c1, c2));
+
+        Page<CommentResponse> page = commentService.getComments(5L, PageRequest.of(0, 1));
+
+        assertThat(page.getTotalElements()).isEqualTo(2);
+        assertThat(page.getContent()).hasSize(1);
+        assertThat(page.getContent().get(0).getId()).isEqualTo(10L);
+        verify(commentRepository).findByPhotoIdOrderByCreatedAt(5L);
+    }
+
+    @Test
+    void secondPageReturnsNextComment() {
+        when(commentRepository.findByPhotoIdOrderByCreatedAt(5L))
+                .thenReturn(List.of(c1, c2));
+
+        Page<CommentResponse> page = commentService.getComments(5L, PageRequest.of(1, 1));
+
+        assertThat(page.getContent()).hasSize(1);
+        assertThat(page.getContent().get(0).getId()).isEqualTo(11L);
+    }
+}


### PR DESCRIPTION
## Summary
- support listing comments ordered by creation time
- implement pagination logic in `CommentService`
- expose endpoint in `CommentController`
- document new endpoint in README
- add unit tests for `CommentService`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686fafa37ef4832ea917b18273281740