### PR TITLE
Add reaction summary endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,17 @@ Response:
 }
 ```
 
+### GET `/api/photos/{photoId}/reactions`
+Return the reaction counts for the photo grouped by type.
+
+Response:
+```json
+[
+  { "type": "heart", "count": 5 },
+  { "type": "like", "count": 3 }
+]
+```
+
 ### DELETE `/api/reactions/{id}`
 Deletes the reaction. Returns **204 No Content** on success.
 
@@ -358,6 +369,16 @@ Response:
     "deviceId": 1,
     "deviceName": "Phone"
   }
+]
+```
+
+### GET `/api/chat/messages/{messageId}/reactions/summary`
+Return the reaction counts for the message grouped by emoji.
+
+Response:
+```json
+[
+  { "emoji": "\uD83D\uDE0A", "count": 2 }
 ]
 ```
 

--- a/weddinggallery/src/main/java/com/weddinggallery/controller/ChatReactionController.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/controller/ChatReactionController.java
@@ -2,6 +2,7 @@ package com.weddinggallery.controller;
 
 import com.weddinggallery.dto.chat.ChatReactionRequest;
 import com.weddinggallery.dto.chat.ChatReactionResponse;
+import com.weddinggallery.dto.chat.ChatReactionCountResponse;
 import com.weddinggallery.service.ChatReactionService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -38,6 +39,15 @@ public class ChatReactionController {
             @RequestHeader(value = "X-client-Id", required = false) String clientId,
             @PathVariable Long messageId) {
         var responses = chatReactionService.getReactions(messageId);
+        return ResponseEntity.ok(responses);
+    }
+
+    @GetMapping("/messages/{messageId}/reactions/summary")
+    @Operation(summary = "Get reaction counts for chat message")
+    public ResponseEntity<List<ChatReactionCountResponse>> getReactionSummary(
+            @RequestHeader(value = "X-client-Id", required = false) String clientId,
+            @PathVariable Long messageId) {
+        var responses = chatReactionService.getReactionSummary(messageId);
         return ResponseEntity.ok(responses);
     }
 

--- a/weddinggallery/src/main/java/com/weddinggallery/controller/ReactionController.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/controller/ReactionController.java
@@ -2,6 +2,7 @@ package com.weddinggallery.controller;
 
 import com.weddinggallery.dto.reaction.ReactionRequest;
 import com.weddinggallery.dto.reaction.ReactionResponse;
+import com.weddinggallery.dto.reaction.ReactionCountResponse;
 import com.weddinggallery.service.ReactionService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -18,6 +19,15 @@ import org.springframework.web.bind.annotation.*;
 public class ReactionController {
 
     private final ReactionService reactionService;
+
+    @GetMapping("/photos/{photoId}/reactions")
+    @Operation(summary = "Get reaction counts for photo")
+    public ResponseEntity<java.util.List<ReactionCountResponse>> getReactions(
+            @RequestHeader(value = "X-client-Id", required = false) String clientId,
+            @PathVariable Long photoId) {
+        var responses = reactionService.getReactionSummary(photoId);
+        return ResponseEntity.ok(responses);
+    }
 
     @PostMapping("/photos/{photoId}/reactions")
     @Operation(summary = "Add reaction to photo",

--- a/weddinggallery/src/main/java/com/weddinggallery/dto/chat/ChatReactionCountResponse.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/dto/chat/ChatReactionCountResponse.java
@@ -1,0 +1,13 @@
+package com.weddinggallery.dto.chat;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatReactionCountResponse {
+    private String emoji;
+    private long count;
+}

--- a/weddinggallery/src/main/java/com/weddinggallery/dto/reaction/ReactionCountResponse.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/dto/reaction/ReactionCountResponse.java
@@ -1,0 +1,13 @@
+package com.weddinggallery.dto.reaction;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReactionCountResponse {
+    private String type;
+    private long count;
+}

--- a/weddinggallery/src/main/java/com/weddinggallery/repository/ChatMessageReactionRepository.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/repository/ChatMessageReactionRepository.java
@@ -1,10 +1,17 @@
 package com.weddinggallery.repository;
 
 import com.weddinggallery.model.ChatMessageReaction;
+import com.weddinggallery.dto.chat.ChatReactionCountResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface ChatMessageReactionRepository extends JpaRepository<ChatMessageReaction, Long> {
     List<ChatMessageReaction> findByMessageIdOrderByCreatedAt(Long messageId);
+
+    @Query("SELECT new com.weddinggallery.dto.chat.ChatReactionCountResponse(r.emoji, COUNT(r)) " +
+           "FROM ChatMessageReaction r WHERE r.message.id = :messageId GROUP BY r.emoji")
+    List<ChatReactionCountResponse> countByMessageIdGroupByEmoji(@Param("messageId") Long messageId);
 }

--- a/weddinggallery/src/main/java/com/weddinggallery/repository/ReactionRepository.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/repository/ReactionRepository.java
@@ -1,8 +1,15 @@
 package com.weddinggallery.repository;
 
 import com.weddinggallery.model.Reaction;
+import com.weddinggallery.dto.reaction.ReactionCountResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ReactionRepository extends JpaRepository<Reaction, Long> {
+
+    @Query("SELECT new com.weddinggallery.dto.reaction.ReactionCountResponse(r.type, COUNT(r)) " +
+           "FROM Reaction r WHERE r.photo.id = :photoId GROUP BY r.type")
+    java.util.List<ReactionCountResponse> countByPhotoIdGroupByType(@Param("photoId") Long photoId);
 }
 

--- a/weddinggallery/src/main/java/com/weddinggallery/service/ChatReactionService.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/service/ChatReactionService.java
@@ -1,6 +1,7 @@
 package com.weddinggallery.service;
 
 import com.weddinggallery.dto.chat.ChatReactionResponse;
+import com.weddinggallery.dto.chat.ChatReactionCountResponse;
 import com.weddinggallery.model.ChatMessage;
 import com.weddinggallery.model.ChatMessageReaction;
 import com.weddinggallery.model.Device;
@@ -62,6 +63,11 @@ public class ChatReactionService {
                 .stream()
                 .map(this::toResponse)
                 .toList();
+    }
+
+    @Transactional
+    public List<ChatReactionCountResponse> getReactionSummary(Long messageId) {
+        return reactionRepository.countByMessageIdGroupByEmoji(messageId);
     }
 
     private ChatReactionResponse toResponse(ChatMessageReaction reaction) {

--- a/weddinggallery/src/main/java/com/weddinggallery/service/ReactionService.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/service/ReactionService.java
@@ -4,6 +4,7 @@ import com.weddinggallery.model.Device;
 import com.weddinggallery.model.Photo;
 import com.weddinggallery.model.Reaction;
 import com.weddinggallery.dto.reaction.ReactionResponse;
+import com.weddinggallery.dto.reaction.ReactionCountResponse;
 import com.weddinggallery.repository.PhotoRepository;
 import com.weddinggallery.repository.ReactionRepository;
 import jakarta.servlet.http.HttpServletRequest;
@@ -55,6 +56,11 @@ public class ReactionService {
         Photo photo = reaction.getPhoto();
         photo.setReactionCount(Math.max(0, photo.getReactionCount() - 1));
         photoRepository.save(photo);
+    }
+
+    @Transactional
+    public java.util.List<ReactionCountResponse> getReactionSummary(Long photoId) {
+        return reactionRepository.countByPhotoIdGroupByType(photoId);
     }
 
     private ReactionResponse toResponse(Reaction reaction) {


### PR DESCRIPTION
## Summary
- add DTOs for grouping reactions
- create repository methods to count reactions by type/emoji
- expose endpoints to retrieve reaction counts for photos and chat messages
- document new endpoints in README

## Testing
- `./mvnw -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686fb50b32c0832e8692fcf3a9bc359d