### PR TITLE
Add device name field

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,12 +4,14 @@ import { login } from './api/auth'
 function App() {
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
+  const [name, setName] = useState('')
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault()
-    await login({ username, password })
+    await login({ username, password, name })
     setUsername('')
     setPassword('')
+    setName('')
   }
 
   return (
@@ -26,6 +28,11 @@ function App() {
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           placeholder="Password"
+        />
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Device Name"
         />
         <button type="submit">Login</button>
       </form>


### PR DESCRIPTION
## Summary
- allow entering a device name in the login form
- send the name to the backend when logging in
- clear the field after successful login

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687012415668832eb3bf1456d8feb4b3