### PR TITLE
Implement gallery filtering with navigation

### DIFF
--- a/frontend/src/pages/GalleryPage.tsx
+++ b/frontend/src/pages/GalleryPage.tsx
@@ -1,7 +1,51 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { getPhotos } from '../api/photos'
+import type { PhotoResponse } from '../types/photo'
+import type { Page } from '../types/page'
 
 function GalleryPage() {
-  return <div>Gallery Page</div>
+  const navigate = useNavigate()
+  const [type, setType] = useState<'image' | 'video' | undefined>()
+  const [page, setPage] = useState(0)
+  const [photos, setPhotos] = useState<Page<PhotoResponse>>()
+
+  useEffect(() => {
+    getPhotos(page, 20, 'uploadTime', 'desc', type).then(setPhotos)
+  }, [page, type])
+
+  const handleFilter = (t: 'image' | 'video' | undefined) => {
+    setPage(0)
+    setType(t)
+  }
+
+  return (
+    <div>
+      <div>
+        <button onClick={() => handleFilter('image')}>Photos</button>
+        <button onClick={() => handleFilter('video')}>Videos</button>
+        <button onClick={() => handleFilter(undefined)}>All</button>
+      </div>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem' }}>
+        {photos?.content.map((p) => (
+          <img
+            key={p.id}
+            src={`/files/${p.fileName}`}
+            alt={p.description ?? ''}
+            style={{ width: '150px', height: '150px', objectFit: 'cover', cursor: 'pointer' }}
+            onClick={() => navigate(`/photos/${p.id}`)}
+          />
+        ))}
+      </div>
+      <div>
+        <button onClick={() => setPage((p) => Math.max(p - 1, 0))} disabled={photos?.first}>Prev</button>
+        <span>
+          {photos ? photos.number + 1 : 0}/{photos?.totalPages ?? 0}
+        </span>
+        <button onClick={() => setPage((p) => p + 1)} disabled={photos?.last}>Next</button>
+      </div>
+    </div>
+  )
 }
 
 export default GalleryPage

--- a/frontend/src/pages/PhotoDetailPage.tsx
+++ b/frontend/src/pages/PhotoDetailPage.tsx
@@ -1,7 +1,30 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { getPhoto } from '../api/photos'
+import type { PhotoResponse } from '../types/photo'
 
 function PhotoDetailPage() {
-  return <div>Photo Detail Page</div>
+  const { id } = useParams<{ id: string }>()
+  const [photo, setPhoto] = useState<PhotoResponse>()
+
+  useEffect(() => {
+    if (id) {
+      getPhoto(Number(id)).then(setPhoto)
+    }
+  }, [id])
+
+  if (!photo) return <div>Loading...</div>
+
+  return (
+    <div>
+      <img
+        src={`/files/${photo.fileName}`}
+        alt={photo.description ?? ''}
+        style={{ maxWidth: '100%' }}
+      />
+      <p>{photo.description}</p>
+    </div>
+  )
 }
 
 export default PhotoDetailPage


### PR DESCRIPTION
## Summary
- fetch photos in GalleryPage using `getPhotos`
- filter by media type via Photos/Videos buttons
- paginate gallery results and navigate to PhotoDetailPage on click
- show photo details when a specific photo is opened

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6870161b12bc832ea9e57a73f0b81461