### PR TITLE
Add STOMP chat logic

### DIFF
--- a/frontend/src/context/ChatContext.tsx
+++ b/frontend/src/context/ChatContext.tsx
@@ -52,6 +52,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   )
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useChat() {
   const ctx = useContext(ChatContext)
   if (!ctx) throw new Error('useChat must be used within ChatProvider')

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,14 +3,11 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
-import { ChatProvider } from './context/ChatContext'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>
-      <ChatProvider>
-        <App />
-      </ChatProvider>
+      <App />
     </BrowserRouter>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- remove `ChatProvider` wrapper
- subscribe to `/topic/chat` in `ChatPage`
- keep a global STOMP client and reconnect if needed
- lint cleanup for `ChatContext`

## Testing
- `npm --prefix frontend run lint`
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68701af5a3bc832ebb08895c308bcc98