### PR TITLE
Add frontend .env.dev example

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ npm run build   # create a production build
 ```
 
 Set the environment variable `VITE_API_URL` to point at the backend API base URL. It defaults to `http://localhost:8080` if not defined.
+For convenience `frontend/.env.dev` contains this default. When running the frontend locally you can:
+
+```bash
+cd frontend
+source .env.dev   # or copy it to .env
+```
+
+so that Vite picks up the setting automatically.
 
 See [`frontend/README.md`](frontend/README.md) for more details.
 

--- a/frontend/.env.dev
+++ b/frontend/.env.dev
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8080

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -25,3 +25,15 @@ npm run build
 ## Configuration
 
 The app expects the environment variable `VITE_API_URL` to specify the backend API base URL. If not set, it falls back to `http://localhost:8080`.
+
+For convenience a `.env.dev` file is included with this default value. When working locally you can either source this file:
+
+```bash
+source .env.dev
+```
+
+or copy it to `.env` so that Vite picks it up automatically:
+
+```bash
+cp .env.dev .env
+```


### PR DESCRIPTION
## Summary
- add `.env.dev` in frontend with example API URL
- document sourcing/copying this file when running frontend

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network)*
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68701f9e7c70832e82d14f92da971719