### PR TITLE
Fix tests and add Maven proxy config

### DIFF
--- a/.mvn/settings.xml.example
+++ b/.mvn/settings.xml.example
@@ -1,0 +1,11 @@
+<settings>
+  <proxies>
+    <proxy>
+      <id>proxy</id>
+      <active>true</active>
+      <protocol>http</protocol>
+      <host>proxy</host>
+      <port>8080</port>
+    </proxy>
+  </proxies>
+</settings>

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ To execute the tests:
 ```bash
 ./mvnw test
 ```
+If your environment requires a proxy to reach Maven Central, copy
+`.mvn/settings.xml.example` to `~/.m2/settings.xml` and update the host
+and port so Maven can download dependencies.
 
 ## Frontend development
 

--- a/weddinggallery/pom.xml
+++ b/weddinggallery/pom.xml
@@ -59,11 +59,16 @@
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>test</scope>
+                </dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/weddinggallery/src/main/java/com/weddinggallery/service/PhotoService.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/service/PhotoService.java
@@ -132,6 +132,8 @@ public class PhotoService {
     }
 
     public void savePhoto(MultipartFile file, String description, HttpServletRequest request) throws IOException {
+        // validate requesting device before queuing the upload
+        deviceService.getRequestingDevice(request);
         String ext = StringUtils.getFilenameExtension(file.getOriginalFilename());
         if (!StringUtils.hasText(ext) || !ALLOWED_EXTENSIONS.contains(ext.toLowerCase())) {
             throw new IllegalArgumentException("Unsupported file extension: " + ext);
@@ -151,6 +153,8 @@ public class PhotoService {
     public void savePhotos(List<MultipartFile> files,
                                             List<String> descriptions,
                                             HttpServletRequest request) throws IOException {
+        // validate requesting device before queuing the uploads
+        deviceService.getRequestingDevice(request);
         if (files == null || files.isEmpty()) {
             return;
         }

--- a/weddinggallery/src/test/java/com/weddinggallery/WeddingGalleryApplicationTests.java
+++ b/weddinggallery/src/test/java/com/weddinggallery/WeddingGalleryApplicationTests.java
@@ -3,7 +3,13 @@ package com.weddinggallery;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.datasource.driverClassName=org.h2.Driver",
+        "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+        "spring.jpa.hibernate.ddl-auto=none",
+        "spring.flyway.enabled=false"
+})
 class WeddingGalleryApplicationTests {
 
     @Test


### PR DESCRIPTION
## Summary
- fix `PhotoService` to validate device before queuing uploads
- enable in-memory DB for `WeddingGalleryApplicationTests`
- add H2 test dependency
- document how to set up a Maven proxy and provide example `settings.xml`

## Testing
- `./mvnw test --settings ~/.m2/settings.xml`

------
https://chatgpt.com/codex/tasks/task_e_6870208328c0832e930e7e9c92849069