### PR TITLE
Fix SockJS global variable

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -37,3 +37,11 @@ or copy it to `.env` so that Vite picks it up automatically:
 ```bash
 cp .env.dev .env
 ```
+
+## Troubleshooting
+
+### SockJS requires `global`
+
+The `sockjs-client` library expects a `global` variable to exist. Vite provides
+this by defining `global: 'globalThis'` in `vite.config.ts`. If you see errors
+mentioning an undefined `global`, ensure this line is present in the config.

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,4 +4,5 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  define: { global: 'globalThis' },
 })


### PR DESCRIPTION
## Summary
- expose `global` var for SockJS in vite config
- document SockJS global var under Troubleshooting

## Testing
- `./mvnw -q test` *(fails: Could not transfer artifact spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_687025c5b90c832e89ff81a0110bff1c