### PR TITLE
Fix isVideo serialization

### DIFF
--- a/frontend/src/api/photos.ts
+++ b/frontend/src/api/photos.ts
@@ -85,7 +85,7 @@ export const downloadArchive = async (): Promise<Blob> => {
 export const updateDescription = async (
   id: number,
   data: PhotoDescriptionUpdateRequest,
-): Promise<String> => {
+): Promise<string> => {
   await axiosInstance.put<PhotoResponse>(`/api/photos/${id}/description`, data)
   return "Opis został zaktualizowany."
 }
@@ -93,7 +93,7 @@ export const updateDescription = async (
 export const updateVisibility = async (
   id: number,
   data: PhotoVisibilityUpdateRequest,
-): Promise<String> => {
+): Promise<string> => {
   await axiosInstance.put<PhotoResponse>(`/api/photos/${id}/visibility`, data)
   return "Zdjęcie zostało usunięte."
 }

--- a/frontend/src/components/Gallery/GalleryTabs.tsx
+++ b/frontend/src/components/Gallery/GalleryTabs.tsx
@@ -33,7 +33,7 @@ const GalleryTabs: React.FC = () => {
                         const counts = await getReactionCounts(item.id);
                         reactions = Object.fromEntries(
                             counts
-                                .filter((r) => EMOJI_MAP[r.type]) // tylko znane typy
+                                .filter((r) => EMOJI_MAP[r.type])
                                 .map((r) => [EMOJI_MAP[r.type], r.count])
                         );
                     } catch (err) {
@@ -42,7 +42,8 @@ const GalleryTabs: React.FC = () => {
 
                     return {
                         id: item.id,
-                        isVideo: item.isVideo,
+                        // support both `isVideo` and legacy `video` property
+                        isVideo: item.isVideo ?? (item as { video?: boolean }).video ?? false,
                         src: `${API_URL}/photos/${item.fileName}`,
                         commentCount: item.commentCount,
                         reactions,

--- a/weddinggallery/src/main/java/com/weddinggallery/dto/photo/PhotoResponse.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/dto/photo/PhotoResponse.java
@@ -3,6 +3,7 @@ package com.weddinggallery.dto.photo;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.LocalDateTime;
 
@@ -20,6 +21,8 @@ public class PhotoResponse {
     private Long deviceId;
     private String deviceName;
     private boolean visible;
+
+    @JsonProperty("isVideo")
     private boolean isVideo;
 }
 


### PR DESCRIPTION
## Summary
- support `video` property from older backend responses
- keep TypeScript strictness and fix linter issues

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68719a5ee2e4832eb34c5c9e606fcb8b