### PR TITLE
Add reusable long press hook for reactions

### DIFF
--- a/frontend/src/components/Gallery/GalleryItem.tsx
+++ b/frontend/src/components/Gallery/GalleryItem.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React from 'react';
 import ReactionSelector from '../Reactions/ReactionSelector';
+import useLongPressReaction from '../../hooks/useLongPressReaction';
 import './GalleryItem.css';
 import {MessageSquare, Heart} from 'lucide-react';
 
@@ -17,19 +18,7 @@ interface GalleryItemProps {
 }
 
 const GalleryItem: React.FC<GalleryItemProps> = ({ item, onItemClick }) => {
-    const [showReactions, setShowReactions] = useState(false);
-    const [reactionTimeout, setReactionTimeout] = useState<NodeJS.Timeout | null>(null);
-
-    const handleHoldStart = () => {
-        // Po ~400ms przytrzymania pokażemy panel reakcji
-        const timeout = setTimeout(() => setShowReactions(true), 400);
-        setReactionTimeout(timeout);
-    };
-
-    const handleHoldEnd = () => {
-        // Anuluj pokazanie panelu, jeśli puszczono przed upływem 400ms
-        if (reactionTimeout) clearTimeout(reactionTimeout);
-    };
+    const { show: showReactions, handlers, close } = useLongPressReaction();
 
     const renderMedia = () => {
         if (item.isVideo) {
@@ -61,11 +50,7 @@ const GalleryItem: React.FC<GalleryItemProps> = ({ item, onItemClick }) => {
         <div className="gallery-item-background">
         <div
             className="gallery-item"
-            onMouseDown={handleHoldStart}
-            onMouseUp={handleHoldEnd}
-            onMouseLeave={handleHoldEnd}
-            onTouchStart={handleHoldStart}
-            onTouchEnd={handleHoldEnd}
+            {...handlers}
             onClick={() => onItemClick?.(item.id)}
         >
             {renderMedia()}
@@ -75,7 +60,7 @@ const GalleryItem: React.FC<GalleryItemProps> = ({ item, onItemClick }) => {
                 <ReactionSelector
                     photoId={item.id}
                     onSelect={() => { /* reakcja zostanie dodana w ReactionSelector */ }}
-                    onClose={() => setShowReactions(false)}
+                    onClose={close}
                 />
             )}
 

--- a/frontend/src/components/Reactions/ReactionSelector.tsx
+++ b/frontend/src/components/Reactions/ReactionSelector.tsx
@@ -13,9 +13,10 @@ import {
 } from 'lucide-react';
 
 interface Props {
-    photoId: number;
-    onSelect: (emoji: string) => void;
+    photoId?: number;
+    onSelect?: (emoji: string) => void;
     onClose: () => void;
+    addReactionFn?: (emoji: string) => Promise<void>;
 }
 
 // mapujemy unicode → typ dla API
@@ -40,12 +41,16 @@ const ICON_MAP: Record<string, React.FC<{ size?: number }>> = {
     '👎': ThumbsDown,
 };
 
-const ReactionSelector: React.FC<Props> = ({ photoId, onSelect, onClose }) => {
+const ReactionSelector: React.FC<Props> = ({ photoId, onSelect, onClose, addReactionFn }) => {
     const handleSelect = async (emoji: string) => {
         const type = EMOJI_MAP[emoji];
         if (!type) return;
-        await addReaction(photoId, { type });
-        onSelect(emoji);
+        if (addReactionFn) {
+            await addReactionFn(emoji);
+        } else if (photoId !== undefined) {
+            await addReaction(photoId, { type });
+        }
+        onSelect?.(emoji);
         onClose();
     };
 

--- a/frontend/src/hooks/useLongPressReaction.ts
+++ b/frontend/src/hooks/useLongPressReaction.ts
@@ -1,0 +1,38 @@
+import { useState, useRef } from 'react';
+
+interface Options {
+  delay?: number;
+}
+
+/**
+ * Hook that exposes handlers for mouse/touch long press to open a reaction selector.
+ */
+export function useLongPressReaction(options?: Options) {
+  const [show, setShow] = useState(false);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const delay = options?.delay ?? 400;
+
+  const start = () => {
+    timeoutRef.current = setTimeout(() => setShow(true), delay);
+  };
+
+  const clear = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  };
+
+  const close = () => setShow(false);
+
+  const handlers = {
+    onMouseDown: start,
+    onMouseUp: clear,
+    onMouseLeave: clear,
+    onTouchStart: start,
+    onTouchEnd: clear,
+  } as const;
+
+  return { show, handlers, close };
+}
+export default useLongPressReaction;


### PR DESCRIPTION
## Summary
- add `useLongPressReaction` hook for reusable long press handlers
- update `ReactionSelector` to support custom reaction functions
- use the new hook in gallery items
- enable long-press reactions on photo detail page comments and photos
- enable long-press reactions in chat messages and remove the old add reaction button

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68761cb6e72c832eb5c97560dc87bd1b