### PR TITLE
Add visibility flags to photo model

### DIFF
--- a/frontend/src/components/Gallery/GalleryGrid.tsx
+++ b/frontend/src/components/Gallery/GalleryGrid.tsx
@@ -10,6 +10,8 @@ export interface GalleryItemData {
     commentCount: number;
     reactionCount: number;
     reactions: Record<string, number>;
+    isVisibleForGuest: boolean;
+    isWish: boolean;
 }
 
 interface GalleryGridProps {

--- a/frontend/src/components/Gallery/GalleryItem.tsx
+++ b/frontend/src/components/Gallery/GalleryItem.tsx
@@ -13,6 +13,8 @@ interface GalleryItemProps {
         commentCount: number;
         reactionCount: number;
         reactions: Record<string, number>;
+        isVisibleForGuest: boolean;
+        isWish: boolean;
     };
     onItemClick?: (id: number) => void;
 }

--- a/frontend/src/components/Gallery/GalleryTabs.tsx
+++ b/frontend/src/components/Gallery/GalleryTabs.tsx
@@ -45,7 +45,9 @@ const GalleryTabs: React.FC<GalleryTabsProps> = ({ onItemClick }) => {
                         src: `${API_URL}/photos/${item.fileName}`,
                         commentCount: item.commentCount,
                         reactionCount: item.reactionCount,
-                        reactions
+                        reactions,
+                        isVisibleForGuest: item.isVisibleForGuest,
+                        isWish: item.isWish
                     };
                 })
             );

--- a/frontend/src/pages/PhotoDetailPage.tsx
+++ b/frontend/src/pages/PhotoDetailPage.tsx
@@ -187,6 +187,12 @@ const PhotoDetailPage: React.FC = () => {
           <div className="photo-info">
             <span className="photo-deviceName">{photo.deviceName}</span>
             <span className="photo-description">{photo.description}</span>
+            {!photo.isVisibleForGuest && (
+                <span className="photo-visibility">Ukryte dla gości</span>
+            )}
+            {photo.isWish && (
+                <span className="photo-wish">🎁</span>
+            )}
           </div>
         </div>
 

--- a/frontend/src/types/photo.ts
+++ b/frontend/src/types/photo.ts
@@ -9,6 +9,8 @@ export interface PhotoResponse {
   deviceId: number;
   deviceName: string;
   visible: boolean;
+  isVisibleForGuest: boolean;
+  isWish: boolean;
   isVideo: boolean;
 }
 


### PR DESCRIPTION
## Summary
- extend `PhotoResponse` with `isVisibleForGuest` and `isWish`
- pass these flags through gallery data structures
- show guest visibility and wish icons on photo detail view

## Testing
- `npm run build`
- `npm run lint`
- `./mvnw -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687634a8455c832e9e34b74e96658040