### PR TITLE
Add wish photo retrieval endpoint

### DIFF
--- a/weddinggallery/src/main/java/com/weddinggallery/controller/PhotoController.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/controller/PhotoController.java
@@ -66,6 +66,22 @@ public class PhotoController {
         return ResponseEntity.ok(result);
     }
 
+    @GetMapping("/wishes")
+    @Operation(summary = "Get wishes")
+    public ResponseEntity<Page<PhotoResponse>> getWishes(
+            @RequestHeader(value = "X-client-Id", required = false) String clientId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(defaultValue = "uploadTime") String sortBy,
+            @RequestParam(defaultValue = "desc") String direction,
+            HttpServletRequest request
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        Sort sort = SortUtil.from(sortBy, direction);
+        var result = photoService.getWishes(pageable, sort, request);
+        return ResponseEntity.ok(result);
+    }
+
     @GetMapping("/{id}")
     @Operation(summary = "Get photo by id")
     public ResponseEntity<PhotoResponse> getPhoto(

--- a/weddinggallery/src/main/java/com/weddinggallery/repository/PhotoSpecifications.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/repository/PhotoSpecifications.java
@@ -21,6 +21,14 @@ public class PhotoSpecifications {
     return (root, query, cb) -> cb.equal(root.get("visible"), visible);
   }
 
+  public static Specification<Photo> isWish(boolean wish) {
+    return (root, query, cb) -> cb.equal(root.get("isWish"), wish);
+  }
+
+  public static Specification<Photo> isVisibleForGuest(boolean visible) {
+    return (root, query, cb) -> cb.equal(root.get("isVisibleForGuest"), visible);
+  }
+
   public static Specification<Photo> withExtensions(Set<String> extensions) {
     return (root, query, cb) -> {
       if (extensions == null || extensions.isEmpty()) {


### PR DESCRIPTION
## Summary
- extend `PhotoSpecifications` with `isWish` and `isVisibleForGuest`
- implement `PhotoService.getWishes` with admin/device checks
- expose `/api/photos/wishes` endpoint in controller

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68763d3e6034832eb285f92417db50d7