### PR TITLE
Add getWishes API

### DIFF
--- a/frontend/src/api/photos.ts
+++ b/frontend/src/api/photos.ts
@@ -25,6 +25,24 @@ export const getPhotos = async (
   return res.data
 }
 
+export const getWishes = async (
+  page = 0,
+  size = 20,
+  sortBy = 'uploadTime',
+  direction = 'desc',
+  type?: string,
+): Promise<Page<PhotoResponse>> => {
+  const params: Record<string, string | number> = {
+    page,
+    size,
+    sortBy,
+    direction,
+  }
+  if (type) params.type = type
+  const res = await axiosInstance.get<Page<PhotoResponse>>('/api/photos/wishes', { params })
+  return res.data
+}
+
 export const getDevicePhotos = async (
   page = 0,
   size = 20,

--- a/frontend/src/pages/WishesPage.tsx
+++ b/frontend/src/pages/WishesPage.tsx
@@ -1,11 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { getPhotos } from '../api/photos';
+import { getWishes } from '../api/photos';
 import type { PhotoResponse } from '../types/photo';
 import GalleryGrid, { type GalleryItemData } from '../components/Gallery/GalleryGrid';
 import WishUploadForm from '../components/Wishes/WishUploadForm';
 import './WishesPage.css';
-import { isAdmin, isThisDevice } from '../utils/authUtils';
 
 const WishesPage: React.FC = () => {
   const [items, setItems] = useState<GalleryItemData[]>([]);
@@ -15,12 +14,8 @@ const WishesPage: React.FC = () => {
   useEffect(() => {
     (async () => {
       try {
-        const page = await getPhotos(0, 100, 'uploadTime', 'desc');
-        const wishes = page.content
-          .filter((p: PhotoResponse) =>
-            p.isWish && (p.isVisibleForGuest || isAdmin() || isThisDevice(p.deviceId))
-          )
-          .map((p: PhotoResponse) => ({
+        const page = await getWishes(0, 100, 'uploadTime', 'desc');
+        const wishes = page.content.map((p: PhotoResponse) => ({
             id: p.id,
             isVideo: p.isVideo ?? false,
             src: `${API_URL}/photos/${p.fileName}`,


### PR DESCRIPTION
## Summary
- add `getWishes` to photos API
- use new `getWishes` in WishesPage to load wishes directly

## Testing
- `npm run build`
- `./mvnw -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687640df79d0832e8e7fa997937309d7