### PR TITLE
Improve photo detail page and upload instructions

### DIFF
--- a/frontend/src/components/Upload/UploadForm.css
+++ b/frontend/src/components/Upload/UploadForm.css
@@ -9,6 +9,13 @@
     margin: 0 auto;
 }
 
+.upload-info {
+    text-align: center;
+    margin-bottom: 8px;
+    color: var(--brown);
+    font-size: 14px;
+}
+
 .dropzone {
     border: 2px dashed var(--gold-bright);
     border-radius: 4px;

--- a/frontend/src/components/Upload/UploadForm.tsx
+++ b/frontend/src/components/Upload/UploadForm.tsx
@@ -70,6 +70,7 @@ const UploadForm: React.FC = () => {
 
     return (
         <div className="upload-form-container">
+            <p className="upload-info">Możesz dodać maksymalnie {MAX_FILES} plików (każdy do {MAX_FILE_SIZE_MB}MB).</p>
             <div {...getRootProps()} className="dropzone">
                 <input {...getInputProps()} />
                 <p>Przeciągnij zdjęcia/filmy lub kliknij</p>

--- a/frontend/src/components/Wishes/WishUploadForm.css
+++ b/frontend/src/components/Wishes/WishUploadForm.css
@@ -7,6 +7,13 @@
     margin: 0 auto 16px;
 }
 
+.wish-info {
+    text-align: center;
+    margin-bottom: 8px;
+    color: var(--brown);
+    font-size: 14px;
+}
+
 .wish-dropzone {
     border: 2px dashed var(--gold-bright);
     border-radius: 4px;

--- a/frontend/src/components/Wishes/WishUploadForm.tsx
+++ b/frontend/src/components/Wishes/WishUploadForm.tsx
@@ -48,6 +48,10 @@ const WishUploadForm: React.FC = () => {
 
   return (
     <div className="wish-upload-container">
+      <p className="wish-info">
+        Tutaj możesz dodać jedno zdjęcie lub film z życzeniami dla nowożeńców.
+        Dodaj opis i wyślij!
+      </p>
       <div {...getRootProps()} className="wish-dropzone">
         <input {...getInputProps()} />
         <p>Przeciągnij plik lub kliknij</p>

--- a/frontend/src/pages/PhotoDetailPage.css
+++ b/frontend/src/pages/PhotoDetailPage.css
@@ -198,6 +198,41 @@
     border-color: var(--gold-bright);
 }
 
+.photo-actions {
+    display: flex;
+    justify-content: center;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+.edit-desc-form {
+    margin-top: 8px;
+}
+
+.update-description-input {
+    width: 100%;
+    border: 1px solid var(--grey-border);
+    border-radius: 6px;
+    padding: 8px;
+    font-size: 14px;
+    resize: vertical;
+    min-height: 40px;
+}
+
+.edit-desc-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+.edit-hint {
+    text-align: center;
+    margin-top: 4px;
+    color: var(--brown);
+    font-size: 14px;
+}
+
 .loading-text {
     text-align: center;
     color: var(--brown);

--- a/frontend/src/pages/PhotoDetailPage.tsx
+++ b/frontend/src/pages/PhotoDetailPage.tsx
@@ -28,6 +28,7 @@ const PhotoDetailPage: React.FC = () => {
   const [commentToDelete, setCommentToDelete] = useState<number | null>(null);
   const [descInput, setDescInput] = useState('');
   const [showEditConfirm, setShowEditConfirm] = useState(false);
+  const [editingDesc, setEditingDesc] = useState(false);
   const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
   const showAlert = useAlerts();
 
@@ -196,19 +197,31 @@ const PhotoDetailPage: React.FC = () => {
           </div>
         </div>
 
-        {(isThisDevice(photo.deviceId) || isAdmin()) && (
-            <button className="btn btn-danger" onClick={() => setShowDeletePhotoConfirm(true)}> Usuń Zdjęcie</button>
+        <div className="photo-actions">
+          {(isThisDevice(photo.deviceId) || isAdmin()) && (
+              <button className="btn btn-danger" onClick={() => setShowDeletePhotoConfirm(true)}>Usuń Zdjęcie</button>
+          )}
+          {isThisDevice(photo.deviceId) && !editingDesc && (
+              <button className="btn btn-primary edit-desc-btn" onClick={() => setEditingDesc(true)}>Edytuj opis</button>
+          )}
+        </div>
+        {isThisDevice(photo.deviceId) && !editingDesc && (
+            <p className="edit-hint">Kliknij "Edytuj opis", aby dodać opis do zdjęcia.</p>
         )}
-        {isThisDevice(photo.deviceId) && (
-            <>
-            <textarea
-                className="update-description-input"
-                placeholder="Dodaj opis..."
-                value={descInput}
-                onChange={e => setDescInput(e.target.value)}
-            />
-            <button className="btn btn-primary" onClick={() => setShowEditConfirm(true)}>Zapisz opis</button>
-            </>
+
+        {isThisDevice(photo.deviceId) && editingDesc && (
+            <div className="edit-desc-form">
+              <textarea
+                  className="update-description-input"
+                  placeholder="Dodaj opis..."
+                  value={descInput}
+                  onChange={e => setDescInput(e.target.value)}
+              />
+              <div className="edit-desc-actions">
+                <button className="btn" onClick={() => { setEditingDesc(false); setDescInput(photo.description || ''); }}>Anuluj</button>
+                <button className="btn btn-primary" onClick={() => setShowEditConfirm(true)}>Zapisz opis</button>
+              </div>
+            </div>
         )}
 
         {/* Sekcja reakcji pod zdjęciem/filmem */}


### PR DESCRIPTION
## Summary
- toggleable description editing on photo detail page
- add helper text for editing descriptions
- show max files and size on upload form
- explain wish upload page usage

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6876c84d5298832e8ed86db5c637ec21