### PR TITLE
Fix delete button style collision

### DIFF
--- a/frontend/src/components/Upload/UploadForm.css
+++ b/frontend/src/components/Upload/UploadForm.css
@@ -80,7 +80,7 @@
     border-color: var(--gold-bright);
 }
 
-.remove-btn {
+.upload-remove-btn {
     align-self: flex-end;
     margin-top: 8px;
     font-size: 12px;

--- a/frontend/src/components/Upload/UploadForm.tsx
+++ b/frontend/src/components/Upload/UploadForm.tsx
@@ -100,7 +100,7 @@ const UploadForm: React.FC = () => {
                                 onChange={e => handleDesc(i, e.target.value)}
                             />
                             <button
-                                className="btn btn-danger remove-btn"
+                                className="btn btn-danger upload-remove-btn"
                                 onClick={() => handleRemove(i)}
                             >Usuń</button>
                         </div>


### PR DESCRIPTION
## Summary
- avoid CSS clash for remove button in `UploadForm`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6876d2470378832eb077c7b0e4832213