### PR TITLE
Fix emoji reaction popup

### DIFF
--- a/frontend/src/components/Gallery/GalleryItem.tsx
+++ b/frontend/src/components/Gallery/GalleryItem.tsx
@@ -53,7 +53,10 @@ const GalleryItem: React.FC<GalleryItemProps> = ({ item, onItemClick }) => {
         <div
             className="gallery-item"
             {...handlers}
-            onClick={() => onItemClick?.(item.id)}
+            onClick={() => {
+                if (showReactions) return;
+                onItemClick?.(item.id);
+            }}
         >
             {renderMedia()}
 

--- a/frontend/src/pages/PhotoDetailPage.css
+++ b/frontend/src/pages/PhotoDetailPage.css
@@ -79,6 +79,7 @@
 }
 
 .reaction-picker-container {
+    position: relative;
     display: flex;
     justify-content: center;
     margin-bottom: 24px;


### PR DESCRIPTION
## Summary
- fix long press detection on gallery items so tapping doesn't navigate away
- position the reaction picker on PhotoDetailPage

## Testing
- `npm run lint`
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6876d73fb834832e86135fc9dac65a21