### PR TITLE
Fix chat reaction bar

### DIFF
--- a/frontend/src/pages/ChatPage.css
+++ b/frontend/src/pages/ChatPage.css
@@ -118,7 +118,7 @@
     outline: none;
     border-color: var(--gold-bright);
 }
-@media screen and (max-width: 405px) {
+@media screen and (max-width: 480px) {
     .reaction-summary {
         flex-wrap: wrap;
         gap: 2px;


### PR DESCRIPTION
## Summary
- adjust chat page CSS so mobile reaction bar no longer gets cut off

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6876d9727738832ebb90cd5ee6caed52