### PR TITLE
Implement mobile-style slider gallery

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "react-dropzone": "^14.3.8",
         "react-easy-crop": "^5.4.2",
         "react-router-dom": "^7.6.3",
+        "react-swipeable": "^7.0.2",
         "sockjs-client": "^1.6.1"
       },
       "devDependencies": {
@@ -3447,6 +3448,15 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-swipeable": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-7.0.2.tgz",
+      "integrity": "sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/requires-port": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "react-dropzone": "^14.3.8",
     "react-easy-crop": "^5.4.2",
     "react-router-dom": "^7.6.3",
+    "react-swipeable": "^7.0.2",
     "sockjs-client": "^1.6.1"
   },
   "devDependencies": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import Navbar from './components/Navbar';
 import LoginPage from './pages/LoginPage';
 import GalleryPage from './pages/GalleryPage';
 import PhotoDetailPage from './pages/PhotoDetailPage';
+import SliderPage from './pages/SliderPage';
 import ChatPage from './pages/ChatPage';
 import UploadPage from './pages/UploadPage';
 import WishesPage from './pages/WishesPage';
@@ -70,6 +71,7 @@ function App() {
         <Routes>
           <Route path="/" element={<GalleryPage />} />
           <Route path="/gallery" element={<GalleryPage />} />
+          <Route path="/slider" element={<SliderPage />} />
           <Route path="/photo/:id" element={<PhotoDetailPage />} />
           <Route path="/upload" element={<UploadPage />} />
           <Route path="/wishes" element={<WishesPage />} />

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -17,6 +17,9 @@ const Navbar: React.FC = () => {
                 <Link to="/gallery" className="nav-link" onClick={closeMenu}>
                     Galeria
                 </Link>
+                <Link to="/slider" className="nav-link" onClick={closeMenu}>
+                    Przeglądaj
+                </Link>
                 <Link to="/upload" className="nav-link" onClick={closeMenu}>
                     Dodaj zdjęcie/film
                 </Link>

--- a/frontend/src/pages/SliderPage.css
+++ b/frontend/src/pages/SliderPage.css
@@ -1,0 +1,94 @@
+.slider-page {
+  padding: 16px;
+  max-width: 448px;
+  margin: 0 auto;
+}
+
+.slider {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.nav-btn {
+  background: none;
+  border: none;
+  padding: 4px;
+  color: var(--brown);
+  cursor: pointer;
+}
+
+.slide-content {
+  flex: 1;
+  text-align: center;
+}
+
+.slide-media {
+  width: 100%;
+  height: auto;
+  border-radius: 8px;
+  max-height: 70vh;
+  object-fit: contain;
+}
+
+.desc {
+  margin-top: 8px;
+  color: var(--brown);
+  font-size: 14px;
+}
+
+.more-btn {
+  margin-left: 8px;
+  color: var(--brown);
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.actions {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  margin-top: 8px;
+}
+
+.icon-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--brown);
+}
+
+.reactions-summary {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.reaction-item {
+  font-size: 20px;
+}
+
+.comments {
+  margin-top: 16px;
+}
+
+.comment-item + .comment-item {
+  margin-top: 8px;
+}
+
+.comment-author {
+  font-weight: 600;
+  margin-right: 4px;
+}
+
+.comment-input {
+  width: 100%;
+  margin-top: 8px;
+  padding: 8px;
+  border-radius: 6px;
+  border: 1px solid var(--grey-border);
+  resize: none;
+}

--- a/frontend/src/pages/SliderPage.tsx
+++ b/frontend/src/pages/SliderPage.tsx
@@ -1,0 +1,170 @@
+import React, { useEffect, useState } from 'react';
+import { useSwipeable } from 'react-swipeable';
+import { getPhotos } from '../api/photos';
+import { getReactionCounts } from '../api/reactions';
+import { getComments, addComment } from '../api/comments';
+import type { PhotoResponse } from '../types/photo';
+import type { CommentResponse } from '../types/comment';
+import ReactionSelector from '../components/Reactions/ReactionSelector';
+import { Heart, MessageSquare, ChevronLeft, ChevronRight } from 'lucide-react';
+import './SliderPage.css';
+
+const EMOJI_MAP: Record<string, string> = {
+  HEART: '❤️',
+  LAUGH: '😂',
+  WOW: '😮',
+  SAD: '😢',
+  ANGRY: '😡',
+  LIKE: '👍',
+  DISLIKE: '👎',
+};
+
+const SliderPage: React.FC = () => {
+  const [photos, setPhotos] = useState<PhotoResponse[]>([]);
+  const [index, setIndex] = useState(0);
+  const [reactions, setReactions] = useState<Record<string, number>>({});
+  const [showPicker, setShowPicker] = useState(false);
+  const [comments, setComments] = useState<CommentResponse[]>([]);
+  const [showComments, setShowComments] = useState(false);
+  const [newComment, setNewComment] = useState('');
+  const [expandedDesc, setExpandedDesc] = useState(false);
+  const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
+
+  useEffect(() => {
+    (async () => {
+      const res = await getPhotos(0, 100, 'uploadTime', 'desc');
+      setPhotos(res.content);
+    })();
+  }, []);
+
+  useEffect(() => {
+    if (!photos[index]) return;
+    const loadData = async () => {
+      const counts = await getReactionCounts(photos[index].id);
+      setReactions(
+        Object.fromEntries(
+          counts.filter(c => EMOJI_MAP[c.type]).map(c => [EMOJI_MAP[c.type], c.count]),
+        ),
+      );
+      const comm = await getComments(photos[index].id, 0, 50);
+      setComments(comm.content);
+      setExpandedDesc(false);
+    };
+    loadData();
+  }, [index, photos]);
+
+  const handlers = useSwipeable({
+    onSwipedLeft: () => next(),
+    onSwipedRight: () => prev(),
+    trackMouse: true,
+  });
+
+  const prev = () => setIndex(i => (i === 0 ? photos.length - 1 : i - 1));
+  const next = () => setIndex(i => (i === photos.length - 1 ? 0 : i + 1));
+
+  const handleAddComment = async () => {
+    if (!newComment.trim()) return;
+    await addComment(photos[index].id, { text: newComment.trim() });
+    const res = await getComments(photos[index].id, 0, 50);
+    setComments(res.content);
+    setNewComment('');
+    setShowComments(true);
+  };
+
+  if (photos.length === 0) {
+    return <p className="loading-text">Ładowanie...</p>;
+  }
+
+  const photo = photos[index];
+  const desc = photo.description || '';
+  const truncated = desc.length > 120 && !expandedDesc ? desc.slice(0, 120) + '…' : desc;
+
+  return (
+    <main className="slider-page">
+      <div className="slider" {...handlers}>
+        <button className="nav-btn left" onClick={prev} aria-label="Poprzednie">
+          <ChevronLeft size={32} />
+        </button>
+        <div className="slide-content">
+          {photo.isVideo ? (
+            <video src={`${API_URL}/photos/${photo.fileName}`} controls className="slide-media" />
+          ) : (
+            <img src={`${API_URL}/photos/${photo.fileName}`} className="slide-media" />
+          )}
+          <div className="desc">
+            <span>{truncated}</span>
+            {desc.length > 120 && (
+              <button className="more-btn" onClick={() => setExpandedDesc(e => !e)}>
+                {expandedDesc ? 'Ukryj' : 'Więcej'}
+              </button>
+            )}
+          </div>
+          <div className="actions">
+            <button className="icon-btn" onClick={() => setShowPicker(v => !v)}>
+              <Heart size={24} />
+            </button>
+            <button className="icon-btn" onClick={() => setShowComments(v => !v)}>
+              <MessageSquare size={24} />
+            </button>
+          </div>
+          {Object.entries(reactions).length > 0 && (
+            <div className="reactions-summary">
+              {Object.entries(reactions).map(([e, c]) => (
+                <span key={e} className="reaction-item">
+                  {e} {c}
+                </span>
+              ))}
+            </div>
+          )}
+          {showPicker && (
+            <ReactionSelector
+              photoId={photo.id}
+              onSelect={() => {
+                setShowPicker(false);
+                getReactionCounts(photo.id).then(counts =>
+                  setReactions(
+                    Object.fromEntries(
+                      counts
+                        .filter(c => EMOJI_MAP[c.type])
+                        .map(c => [EMOJI_MAP[c.type], c.count]),
+                    ),
+                  ),
+                );
+              }}
+              onClose={() => setShowPicker(false)}
+            />
+          )}
+        </div>
+        <button className="nav-btn right" onClick={next} aria-label="Następne">
+          <ChevronRight size={32} />
+        </button>
+      </div>
+
+      {showComments && (
+        <section className="comments">
+          {comments.map(c => (
+            <div key={c.id} className="comment-item">
+              <span className="comment-author">{c.deviceName}</span>
+              <span>{c.text}</span>
+            </div>
+          ))}
+          <textarea
+            className="comment-input"
+            rows={2}
+            value={newComment}
+            onChange={e => setNewComment(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                handleAddComment();
+              }
+            }}
+            placeholder="Dodaj komentarz…"
+          />
+        </section>
+      )}
+    </main>
+  );
+};
+
+export default SliderPage;


### PR DESCRIPTION
## Summary
- add a new `SliderPage` for browsing photos one by one
- support swiping or buttons to move between photos
- allow adding reactions and comments directly from the slider
- collapse long descriptions with a button to expand
- link the slider from the navbar and routing
- install `react-swipeable` for gesture support

## Testing
- `npm run build`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6876dde801b4832eb470b6cac5850f1e