### PR TITLE
Fix mobile slider image fit

### DIFF
--- a/frontend/src/pages/SliderPage.css
+++ b/frontend/src/pages/SliderPage.css
@@ -138,7 +138,7 @@
     inset: 0;
     width: 100%;
     height: 100%;
-    object-fit: cover;
+    object-fit: contain;
     border-radius: 0;
   }
 


### PR DESCRIPTION
## Summary
- prevent cropping on mobile slider images

## Testing
- `npm run lint`
- `npm run build`
- `./mvnw test` *(fails: Could not resolve Spring dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68774ea58724832e98fc7a09b2169a51