### PR TITLE
Add guest visibility update

### DIFF
--- a/frontend/src/api/photos.ts
+++ b/frontend/src/api/photos.ts
@@ -4,6 +4,7 @@ import type {
   PhotoResponse,
   PhotoDescriptionUpdateRequest,
   PhotoVisibilityUpdateRequest,
+  PhotoGuestVisibilityUpdateRequest,
 } from '../types/photo'
 import type { Page } from '../types/page'
 
@@ -125,4 +126,12 @@ export const updateVisibility = async (
 ): Promise<string> => {
   await axiosInstance.put<PhotoResponse>(`/api/photos/${id}/visibility`, data)
   return "Zdjęcie zostało usunięte."
+}
+
+export const updateGuestVisibility = async (
+  id: number,
+  data: PhotoGuestVisibilityUpdateRequest,
+): Promise<string> => {
+  await axiosInstance.put<PhotoResponse>(`/api/photos/${id}/guest-visibility`, data)
+  return "Widoczność dla gości zaktualizowana."
 }

--- a/frontend/src/types/photo.ts
+++ b/frontend/src/types/photo.ts
@@ -21,3 +21,7 @@ export interface PhotoDescriptionUpdateRequest {
 export interface PhotoVisibilityUpdateRequest {
   visible: boolean;
 }
+
+export interface PhotoGuestVisibilityUpdateRequest {
+  isVisibleForGuest: boolean;
+}

--- a/weddinggallery/src/main/java/com/weddinggallery/controller/PhotoController.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/controller/PhotoController.java
@@ -4,6 +4,7 @@ import com.weddinggallery.dto.photo.PhotoResponse;
 import com.weddinggallery.service.PhotoService;
 import com.weddinggallery.dto.photo.PhotoDescriptionUpdateRequest;
 import com.weddinggallery.dto.photo.PhotoVisibilityUpdateRequest;
+import com.weddinggallery.dto.photo.PhotoGuestVisibilityUpdateRequest;
 import com.weddinggallery.util.SortUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -176,6 +177,18 @@ public class PhotoController {
     ) {
         photoService.updatePhotoVisibility(id, updateRequest.isVisible(), request);
         return ResponseEntity.ok("Visibility updated successfully.");
+    }
+
+    @PutMapping("/{id}/guest-visibility")
+    @Operation(summary = "Update photo guest visibility")
+    public ResponseEntity<String> updateGuestVisibility(
+            @RequestHeader(value = "X-client-Id", required = false) String clientId,
+            @PathVariable Long id,
+            @RequestBody PhotoGuestVisibilityUpdateRequest updateRequest,
+            HttpServletRequest request
+    ) {
+        photoService.updatePhotoGuestVisibility(id, updateRequest.isVisibleForGuest(), request);
+        return ResponseEntity.ok("Guest visibility updated successfully.");
     }
 
 

--- a/weddinggallery/src/main/java/com/weddinggallery/dto/photo/PhotoGuestVisibilityUpdateRequest.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/dto/photo/PhotoGuestVisibilityUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.weddinggallery.dto.photo;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PhotoGuestVisibilityUpdateRequest {
+    private boolean isVisibleForGuest;
+}


### PR DESCRIPTION
## Summary
- add `PhotoGuestVisibilityUpdateRequest` DTO
- support updating guest visibility in `PhotoService`
- expose `PUT /api/photos/{id}/guest-visibility`
- extend frontend API and types for the new request

## Testing
- `npm run lint`
- `mvn -q test` *(fails: Non-resolvable parent POM because network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687791c62288832eaed324cda87d3b58