### PR TITLE
Add access checks when retrieving photos

### DIFF
--- a/weddinggallery/src/main/java/com/weddinggallery/controller/PhotoController.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/controller/PhotoController.java
@@ -87,9 +87,10 @@ public class PhotoController {
     @Operation(summary = "Get photo by id")
     public ResponseEntity<PhotoResponse> getPhoto(
             @RequestHeader(value = "X-client-Id", required = false) String clientId,
-            @PathVariable Long id
+            @PathVariable Long id,
+            HttpServletRequest request
     ) {
-        PhotoResponse response = photoService.getPhoto(id);
+        PhotoResponse response = photoService.getPhoto(id, request);
         return ResponseEntity.ok(response);
     }
 

--- a/weddinggallery/src/test/java/com/weddinggallery/controller/PhotoControllerMvcTest.java
+++ b/weddinggallery/src/test/java/com/weddinggallery/controller/PhotoControllerMvcTest.java
@@ -3,6 +3,7 @@ package com.weddinggallery.controller;
 import com.weddinggallery.security.JwtTokenProvider;   // <– importujemy
 import com.weddinggallery.service.PhotoService;
 import com.weddinggallery.dto.photo.PhotoResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,7 +43,7 @@ class PhotoControllerMvcTest {
 
     @Test
     void getPhotoByIdReturnsOk() throws Exception {
-        Mockito.when(photoService.getPhoto(1L))
+        Mockito.when(photoService.getPhoto(Mockito.eq(1L), Mockito.any(HttpServletRequest.class)))
                 .thenReturn(new PhotoResponse());
 
         mockMvc.perform(get("/api/photos/1"))


### PR DESCRIPTION
## Summary
- enforce owner/admin visibility check in `PhotoService.getPhoto`
- forward request in `PhotoController.getPhoto`
- adjust MVC test for new method signature

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687796c168c8832e9a552191debaccd4