### PR TITLE
Rename guest visibility state in wish upload form

### DIFF
--- a/frontend/src/components/Wishes/WishUploadForm.tsx
+++ b/frontend/src/components/Wishes/WishUploadForm.tsx
@@ -10,7 +10,7 @@ const WishUploadForm: React.FC = () => {
   const [file, setFile] = useState<File | null>(null);
   const [description, setDescription] = useState('');
   const [progress, setProgress] = useState(0);
-  const [visible, setVisible] = useState(true);
+  const [visibleForGuest, setVisibleForGuest] = useState(true);
   const showAlert = useAlerts();
 
   const onDrop = useCallback((accepted: File[]) => {
@@ -32,7 +32,7 @@ const WishUploadForm: React.FC = () => {
   const handleUpload = async () => {
     if (!file) return;
     try {
-      await savePhoto(file, description, visible, e => {
+      await savePhoto(file, description, visibleForGuest, e => {
         setProgress(Math.round((e.loaded * 100) / (e.total || 1)));
       });
       showAlert('Wysłano!', 'success');
@@ -76,8 +76,8 @@ const WishUploadForm: React.FC = () => {
       <label className="visible-checkbox">
         <input
           type="checkbox"
-          checked={visible}
-          onChange={e => setVisible(e.target.checked)}
+          checked={visibleForGuest}
+          onChange={e => setVisibleForGuest(e.target.checked)}
         />
         Widoczne dla gości
       </label>


### PR DESCRIPTION
## Summary
- rename `visible` state to `visibleForGuest`
- update checkbox binding to use the new state name
- pass the updated variable to `savePhoto`

## Testing
- `./mvnw -q test` *(fails: Could not resolve dependencies)*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68779e89104c832eb81c8bbc28d0c510