### PR TITLE
Fix JSON property for guest visibility

### DIFF
--- a/weddinggallery/src/main/java/com/weddinggallery/dto/photo/PhotoGuestVisibilityUpdateRequest.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/dto/photo/PhotoGuestVisibilityUpdateRequest.java
@@ -3,10 +3,12 @@ package com.weddinggallery.dto.photo;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class PhotoGuestVisibilityUpdateRequest {
+    @JsonProperty("isVisibleForGuest")
     private boolean isVisibleForGuest;
 }

--- a/weddinggallery/src/main/java/com/weddinggallery/dto/photo/PhotoResponse.java
+++ b/weddinggallery/src/main/java/com/weddinggallery/dto/photo/PhotoResponse.java
@@ -21,7 +21,9 @@ public class PhotoResponse {
     private Long deviceId;
     private String deviceName;
     private boolean visible;
+    @JsonProperty("isVisibleForGuest")
     private boolean isVisibleForGuest;
+    @JsonProperty("isWish")
     private boolean isWish;
     @JsonProperty("isVideo")
     private boolean isVideo;


### PR DESCRIPTION
## Summary
- expose `isVisibleForGuest` and `isWish` fields with the same names in JSON
- annotate guest visibility update DTO to accept `isVisibleForGuest`

## Testing
- `mvnw test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687812b802d4832e9d291d6e76914de8