### PR TITLE
Add heart double-tap animation and fix gallery reactions

### DIFF
--- a/frontend/src/components/Gallery/GalleryItem.css
+++ b/frontend/src/components/Gallery/GalleryItem.css
@@ -9,7 +9,7 @@
     justify-content: center;
     align-items: center;
 
-    overflow: hidden;
+    overflow: visible;
 }
 
 .gallery-item-background img {
@@ -23,7 +23,7 @@
     height: 100%;
     cursor: pointer;
     aspect-ratio: 1 / 1;
-    overflow: hidden;
+    overflow: visible;
     border-radius: 8px;
 }
 

--- a/frontend/src/components/SliderModal.css
+++ b/frontend/src/components/SliderModal.css
@@ -18,6 +18,13 @@
   justify-content: center;
 }
 
+.media-wrapper {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
 .slider-media {
   max-width: 100%;
   max-height: 90vh;
@@ -69,4 +76,24 @@
 .thumbnail.active {
   border: 2px solid var(--gold-bright);
   opacity: 1;
+}
+
+@keyframes heart-fade {
+  0% {
+    transform: translate(-50%, -50%) scale(2);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 0;
+  }
+}
+
+.double-tap-heart {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  font-size: 96px;
+  pointer-events: none;
+  animation: heart-fade 0.8s forwards;
 }

--- a/frontend/src/components/SliderModal.tsx
+++ b/frontend/src/components/SliderModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { getPhotos } from '../api/photos';
@@ -18,6 +18,8 @@ interface MediaItem {
 const SliderModal: React.FC<SliderModalProps> = ({ startId, onClose }) => {
   const [items, setItems] = useState<MediaItem[]>([]);
   const [index, setIndex] = useState(0);
+  const [heartKey, setHeartKey] = useState<number>(0);
+  const lastTapRef = useRef<number>(0);
   const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
 
   const fetchItems = useCallback(async () => {
@@ -55,17 +57,34 @@ const SliderModal: React.FC<SliderModalProps> = ({ startId, onClose }) => {
   const next = () => setIndex(i => (i === items.length - 1 ? 0 : i + 1));
   const current = items[index];
 
+  const showHeart = () => {
+    setHeartKey(Date.now());
+  };
+
+  const handleTap = () => {
+    const now = Date.now();
+    if (now - lastTapRef.current < 300) {
+      showHeart();
+    }
+    lastTapRef.current = now;
+  };
+
   const modal = (
     <div className="slider-modal-backdrop" onClick={onClose}>
       <div className="slider-modal" onClick={e => e.stopPropagation()}>
         <button className="nav-btn left" onClick={prev} aria-label="Poprzednie">
           <ChevronLeft size={32} />
         </button>
-        {current.isVideo ? (
-          <video src={current.src} controls className="slider-media" />
-        ) : (
-          <img src={current.src} className="slider-media" />
-        )}
+        <div className="media-wrapper" onClick={handleTap} onDoubleClick={showHeart}>
+          {current.isVideo ? (
+            <video src={current.src} controls className="slider-media" />
+          ) : (
+            <img src={current.src} className="slider-media" />
+          )}
+          {heartKey > 0 && (
+            <span key={heartKey} className="double-tap-heart">❤️</span>
+          )}
+        </div>
         <button className="nav-btn right" onClick={next} aria-label="Następne">
           <ChevronRight size={32} />
         </button>


### PR DESCRIPTION
## Summary
- add a heart animation on double tap in `SliderModal`
- expose `ReactionSelector` by removing hidden overflow from gallery items
- style the new animation and wrapper

## Testing
- `npm run lint`
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687816a3c394832e953b5741753b1c36