### PR TITLE
Fix slider reactions and mobile emoji layout

### DIFF
--- a/frontend/src/components/Reactions/ReactionSelector.css
+++ b/frontend/src/components/Reactions/ReactionSelector.css
@@ -29,3 +29,16 @@
     line-height: 1;
 }
 
+@media (max-width: 480px) {
+    .reaction-selector {
+        flex-wrap: wrap;
+        max-width: calc(100vw - 32px);
+        gap: 6px;
+        padding: 6px 8px;
+    }
+
+    .reaction-selector .reaction-emoji {
+        font-size: 20px;
+    }
+}
+

--- a/frontend/src/components/SliderModal.css
+++ b/frontend/src/components/SliderModal.css
@@ -97,3 +97,80 @@
   pointer-events: none;
   animation: heart-fade 0.8s forwards;
 }
+
+.comments-section {
+  margin-top: 12px;
+  width: 100%;
+}
+
+.comments-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--cream-light);
+  margin-bottom: 8px;
+  text-align: center;
+}
+
+.no-comments-msg {
+  color: var(--cream-light);
+  text-align: center;
+}
+
+.comment-list {
+  list-style: none;
+  padding-left: 0;
+  max-height: 150px;
+  overflow-y: auto;
+}
+
+.comment-list .comment-item + .comment-item {
+  margin-top: 8px;
+}
+
+.comment-item {
+  display: flex;
+  align-items: flex-start;
+}
+
+.comment-avatar {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  background-color: var(--brown);
+  color: var(--cream-light);
+  font-family: 'Playfair Display', serif;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 8px;
+}
+
+.comment-bubble {
+  background-color: var(--white);
+  padding: 8px;
+  border-radius: 12px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  font-size: 14px;
+  flex: 1;
+}
+
+.comment-author {
+  color: var(--brown);
+  font-weight: 500;
+}
+
+.comment-input {
+  width: 100%;
+  border: 1px solid var(--grey-border);
+  border-radius: 6px;
+  padding: 8px;
+  font-size: 14px;
+  margin-top: 12px;
+  resize: none;
+}
+
+.comment-input:focus {
+  outline: none;
+  border-color: var(--gold-bright);
+}


### PR DESCRIPTION
## Summary
- support wrapping the emoji selector on small screens
- allow adding heart reaction in `SliderModal`
- show emoji picker and comment section in slider

## Testing
- `npm run lint`
- `npm run build`
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68781987def8832ea6e3a75c878dbb43