### PR TITLE
Add comment/reaction controls in slider

### DIFF
--- a/frontend/src/components/SliderModal.css
+++ b/frontend/src/components/SliderModal.css
@@ -174,3 +174,24 @@
   outline: none;
   border-color: var(--gold-bright);
 }
+
+.action-bar {
+  position: absolute;
+  bottom: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 16px;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+  padding: 4px 12px;
+  border-radius: 20px;
+  color: var(--white);
+}
+
+.action-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+}

--- a/frontend/src/hooks/useLongPressReaction.ts
+++ b/frontend/src/hooks/useLongPressReaction.ts
@@ -24,6 +24,7 @@ export function useLongPressReaction(options?: Options) {
   };
 
   const close = () => setShow(false);
+  const open = () => setShow(true);
 
   const handlers = {
     onMouseDown: start,
@@ -33,6 +34,6 @@ export function useLongPressReaction(options?: Options) {
     onTouchEnd: clear,
   } as const;
 
-  return { show, handlers, close };
+  return { show, handlers, close, open };
 }
 export default useLongPressReaction;


### PR DESCRIPTION
## Summary
- expose `open` helper in `useLongPressReaction`
- show comment and reaction counters in `SliderModal`
- toggle comment form and open reaction picker from icons
- update slider styles for new action bar

## Testing
- `./mvnw -q test` *(fails: could not resolve Spring dependencies)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68781cb3937c832ea64b9b456f02a5f3