### PR TITLE
Fix reaction selector placement and tap detection

### DIFF
--- a/frontend/src/components/Reactions/ReactionSelector.css
+++ b/frontend/src/components/Reactions/ReactionSelector.css
@@ -1,9 +1,9 @@
 .reaction-selector {
     position: absolute;
-    bottom: 100%;
+    top: 100%;
     left: 50%;
     transform: translateX(-50%);
-    margin-bottom: 8px;
+    margin-top: 8px;
     background-color: var(--white);
     border-radius: 9999px;
     box-shadow: 0 10px 15px -3px rgba(168, 151, 120, 0.39), 0 4px 6px -4px rgba(166, 123, 53, 0.1);

--- a/frontend/src/components/SliderModal.tsx
+++ b/frontend/src/components/SliderModal.tsx
@@ -112,6 +112,10 @@ const SliderModal: React.FC<SliderModalProps> = ({ startId, onClose }) => {
   };
 
   const handleTap = () => {
+    if (showPicker) {
+      lastTapRef.current = 0;
+      return;
+    }
     const now = Date.now();
     if (now - lastTapRef.current < 300) {
       showHeart();


### PR DESCRIPTION
## Summary
- position reaction selector below images
- ignore taps while reaction menu is open to prevent accidental hearts

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6878a497ccec832e9f949eaf26f4adee