### PR TITLE
Fix mobile reaction selector layout

### DIFF
--- a/frontend/src/components/Reactions/ReactionSelector.css
+++ b/frontend/src/components/Reactions/ReactionSelector.css
@@ -31,10 +31,12 @@
 
 @media (max-width: 480px) {
     .reaction-selector {
-        flex-wrap: wrap;
+        flex-wrap: nowrap;
         max-width: calc(100vw - 32px);
         gap: 6px;
         padding: 6px 8px;
+        overflow-x: auto;
+        white-space: nowrap;
     }
 
     .reaction-selector .reaction-emoji {


### PR DESCRIPTION
## Summary
- keep reactions on a single line in `ReactionSelector` on small screens
- enable horizontal scrolling for overflowing emojis

## Testing
- `npm run lint`
- `npm run build` *(fails: TS2554)*
- `./mvnw test` *(fails: could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6878d1e23b4c832e8b75c07432d83574