### PR TITLE
Introduce ReactionSummary component

### DIFF
--- a/frontend/src/components/Reactions/ReactionSummary.css
+++ b/frontend/src/components/Reactions/ReactionSummary.css
@@ -1,0 +1,35 @@
+.reaction-summary {
+    margin-top: 4px;
+    font-size: 12px;
+    display: flex;
+    color: var(--brown);
+}
+.reaction-summary.own {
+    justify-content: flex-end;
+}
+.reaction-summary.center {
+    justify-content: center;
+}
+.reaction-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+@media screen and (max-width: 480px) {
+    .reaction-summary {
+        flex-wrap: wrap;
+        gap: 2px;
+        padding: 0 4px;
+        box-sizing: border-box;
+        width: 100%;
+    }
+    .reaction-item {
+        font-size: 10px;
+        padding: 1px 3px;
+        border-radius: 10px;
+        background: rgba(0,0,0,0.05);
+    }
+    .reaction-item > span:first-child {
+        margin-right: 1px;
+    }
+}

--- a/frontend/src/components/Reactions/ReactionSummary.tsx
+++ b/frontend/src/components/Reactions/ReactionSummary.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import './ReactionSummary.css';
+
+interface ReactionSummaryProps {
+    reactions: Record<string, number>;
+    className?: string;
+}
+
+const ReactionSummary: React.FC<ReactionSummaryProps> = ({ reactions, className }) => {
+    const entries = Object.entries(reactions);
+    if (entries.length === 0) return null;
+    return (
+        <div className={`reaction-summary${className ? ` ${className}` : ''}`}>
+            {entries.map(([emoji, count]) => (
+                <span key={emoji} className="reaction-item">
+                    <span>{emoji}</span>
+                    <span>{count}</span>
+                </span>
+            ))}
+        </div>
+    );
+};
+
+export default ReactionSummary;

--- a/frontend/src/pages/ChatPage.css
+++ b/frontend/src/pages/ChatPage.css
@@ -84,21 +84,6 @@
     transform: scale(1.2);
 }
 
-.reaction-summary {
-    margin-top: 4px;
-    font-size: 12px;
-    display: flex;
-    color: var(--brown);
-}
-.reaction-summary.own {
-    justify-content: flex-end;
-}
-
-.reaction-item {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-}
 
 .chat-input-area {
     display: flex;
@@ -119,24 +104,6 @@
     border-color: var(--gold-bright);
 }
 @media screen and (max-width: 480px) {
-    .reaction-summary {
-        flex-wrap: wrap;
-        gap: 2px;
-        padding: 0 4px;
-        box-sizing: border-box;
-        width: 100%;
-    }
-
-    .reaction-item {
-        font-size: 10px;
-        padding: 1px 3px;
-        border-radius: 10px;
-        background: rgba(0,0,0,0.05);
-    }
-
-    .reaction-item > span:first-child {
-        margin-right: 1px;
-    }
 
     .emoji-picker {
         left: 50%;

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -12,6 +12,7 @@ import type { ChatMessageResponse, ChatReactionCountResponse } from '../types/ch
 import './ChatPage.css';
 import { useAlerts } from "../components/alert/useAlerts"
 import ReactionSelector from '../components/Reactions/ReactionSelector';
+import ReactionSummary from '../components/Reactions/ReactionSummary';
 import useLongPressReaction from '../hooks/useLongPressReaction';
 
 function ChatMessage({ message }: { message: ChatMessageResponse }) {
@@ -73,16 +74,10 @@ function ChatMessage({ message }: { message: ChatMessageResponse }) {
             </div>
         )}
 
-        {reactions.length > 0 && (
-            <div className={`reaction-summary ${isOwn ? 'own' : ''}`}>
-              {reactions.map(r => (
-                  <span key={r.emoji} className="reaction-item">
-              <span>{r.emoji}</span>
-              <span>{r.count}</span>
-            </span>
-              ))}
-            </div>
-        )}
+        <ReactionSummary
+            reactions={Object.fromEntries(reactions.map(r => [r.emoji, r.count]))}
+            className={isOwn ? 'own' : undefined}
+        />
       </div>
   );
 }

--- a/frontend/src/pages/PhotoDetailPage.css
+++ b/frontend/src/pages/PhotoDetailPage.css
@@ -58,25 +58,10 @@
     margin-top: 4px;
 }
 
-.reactions-container {
-    display: flex;
-    justify-content: center;
-    flex-wrap: wrap;
-    gap: 8px;
+.reaction-summary.center {
     margin-bottom: 12px;
-    color: var(--brown);
 }
 
-.reaction {
-    font-size: 20px;
-    display: flex;
-    align-items: center;
-    gap: 4px;
-}
-
-.reaction-count {
-    font-size: 14px;
-}
 
 .reaction-picker-container {
     position: relative;

--- a/frontend/src/pages/PhotoDetailPage.tsx
+++ b/frontend/src/pages/PhotoDetailPage.tsx
@@ -11,6 +11,7 @@ import { useAlerts } from "../components/alert/useAlerts"
 import ConfirmModal from "../components/Confirm/ConfirmModal";
 import useLongPressReaction from '../hooks/useLongPressReaction';
 import ReactionSelector from '../components/Reactions/ReactionSelector';
+import ReactionSummary from '../components/Reactions/ReactionSummary';
 
 const EMOJI_MAP: Record<string, string> = {
   HEART: '❤️', LAUGH: '😂', WOW: '😮', SAD: '😢',
@@ -258,14 +259,7 @@ const PhotoDetailPage: React.FC = () => {
         )}
 
         {/* Sekcja reakcji pod zdjęciem/filmem */}
-        <div className="reactions-container">
-          {Object.entries(reactions).map(([emoji, count]) => (
-              <div key={emoji} className="reaction">
-                <span>{emoji}</span>
-                <span className="reaction-count">{count}</span>
-              </div>
-          ))}
-        </div>
+        <ReactionSummary reactions={reactions} className="center" />
         {showPicker && (
           <div className="reaction-picker-container">
             <ReactionSelector


### PR DESCRIPTION
## Summary
- add reusable `ReactionSummary` component for displaying emoji counts
- update chat and photo detail pages to use `ReactionSummary`
- move reaction summary styling into a dedicated CSS file
- remove old markup/styling no longer needed

## Testing
- `npm run lint`
- `npm run build` *(fails: TS2554 in SliderModal.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6878d2f162ac832e96b6318df25cf860