### PR TITLE
Improve accessibility of reaction buttons

### DIFF
--- a/frontend/src/components/Reactions/ReactionSelector.tsx
+++ b/frontend/src/components/Reactions/ReactionSelector.tsx
@@ -21,6 +21,17 @@ const EMOJI_MAP: Record<string, string> = {
     '👎': 'DISLIKE',
 };
 
+// Labels used for screen readers
+const EMOJI_LABELS: Record<string, string> = {
+    '❤️': 'Heart',
+    '😂': 'Laugh',
+    '😮': 'Wow',
+    '😢': 'Sad',
+    '😡': 'Angry',
+    '👍': 'Like',
+    '👎': 'Dislike',
+};
+
 
 const ReactionSelector: React.FC<Props> = ({ photoId, onSelect, onClose, addReactionFn }) => {
     const containerRef = useRef<HTMLDivElement>(null);
@@ -56,13 +67,14 @@ const ReactionSelector: React.FC<Props> = ({ photoId, onSelect, onClose, addReac
             {Object.keys(EMOJI_MAP).map(emoji => (
                 <button
                     key={emoji}
-                    aria-label={`Reakcja ${emoji}`}
+                    aria-label={`${EMOJI_LABELS[emoji]} reaction`}
                     onClick={e => {
                         e.stopPropagation();
                         handleSelect(emoji);
                     }}
                 >
-                    <span className="reaction-emoji">{emoji}</span>
+                    <span aria-hidden="true" className="reaction-emoji">{emoji}</span>
+                    <span className="sr-only">{`${EMOJI_LABELS[emoji]} reaction`}</span>
                 </button>
             ))}
         </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -31,3 +31,16 @@ body {
   background-attachment: fixed; /* tło nie przewija się */
 }
 
+/* Visually hidden text for accessibility */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+


### PR DESCRIPTION
## Summary
- add readable labels for reaction emojis
- include hidden text for screen readers
- define `.sr-only` style in global CSS

## Testing
- `npm run lint`
- `./mvnw test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6878d5a9d4ac832e970e7d1cfdf6f62d