### PR TITLE
Disable double-tap zoom in slider

### DIFF
--- a/frontend/src/components/SliderModal.css
+++ b/frontend/src/components/SliderModal.css
@@ -25,6 +25,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  touch-action: manipulation;
 }
 
 .slider-media {


### PR DESCRIPTION
## Summary
- prevent mobile pinch zoom on slider media wrapper by setting `touch-action: manipulation`

## Testing
- `npm install`
- `npm run build` *(fails: Property 'triggerRef' is missing in type { onClose: () => void; addReactionFn: (emoji: string) => Promise<void>; } but required in type 'Props')*

------
https://chatgpt.com/codex/tasks/task_e_68796ede7c38832eb9fecb14775c0ff1